### PR TITLE
Add a pytest characterization safety net (1,413 tests)

### DIFF
--- a/komga_cover_extractor.py
+++ b/komga_cover_extractor.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 import argparse
 import cProfile
-import hashlib
+import xxhash
 import io
 import os
 import re
 import shutil
 import string
-import struct
 import subprocess
 import sys
 import tempfile
@@ -15,32 +14,30 @@ import threading
 import time
 import traceback
 import urllib.request
-import xml.etree.ElementTree as ET
 import zipfile
-from base64 import b64encode
 from datetime import datetime
-from difflib import SequenceMatcher
+from rapidfuzz.distance import Indel
 from functools import lru_cache
 from posixpath import join
 from urllib.parse import urlparse
 
-import cv2
 import filetype
-import numpy as np
+import imagehash
 import py7zr
 import rarfile
 import regex as re
 import requests
-import scandir
 from bs4 import BeautifulSoup
 from discord_webhook import DiscordEmbed, DiscordWebhook
 from lxml import etree
-from PIL import Image
-from skimage.metrics import structural_similarity as ssim
+from PIL import Image, ImageChops, ImageStat
 from titlecase import titlecase
 from unidecode import unidecode
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
+from requests.auth import HTTPBasicAuth
+from tenacity import retry, retry_if_exception, retry_if_exception_type, stop_after_attempt, wait_fixed
+import xmltodict
 
 # Get all the variables in settings.py
 import settings as settings_file
@@ -134,6 +131,20 @@ blank_white_image_path = (
 blank_black_image_path = (
     os.path.join(ROOT_DIR, "blank_black.png")
     if os.path.isfile(os.path.join(ROOT_DIR, "blank_black.png"))
+    else None
+)
+
+# Precompute the perceptual hashes of the blank reference images once at startup
+# so the blank-image similarity check does not re-hash them on every call.
+# phash returns a 64-bit ImageHash; similarity is derived as 1 - (hamming / 64).
+blank_white_image_hash = (
+    imagehash.phash(Image.open(blank_white_image_path))
+    if blank_white_image_path
+    else None
+)
+blank_black_image_hash = (
+    imagehash.phash(Image.open(blank_black_image_path))
+    if blank_black_image_path
     else None
 )
 
@@ -801,7 +812,7 @@ def get_file_size(file_path):
 def get_all_folders_recursively_in_dir(dir_path):
     results = []
 
-    for root, dirs, files in scandir.walk(dir_path):
+    for root, dirs, files in os.walk(dir_path):
         if root in download_folders + paths:
             continue
 
@@ -815,7 +826,7 @@ def get_all_folders_recursively_in_dir(dir_path):
 # Recursively gets all the files in a directory
 def get_all_files_in_directory(dir_path):
     results = []
-    for root, dirs, files in scandir.walk(dir_path):
+    for root, dirs, files in os.walk(dir_path):
         files = remove_hidden_files(files)
         files = remove_unaccepted_file_types(files, root, file_extensions)
         results.extend(files)
@@ -825,7 +836,7 @@ def get_all_files_in_directory(dir_path):
 # Resursively gets all files in a directory for watchdog
 def get_all_files_recursively_in_dir_watchdog(dir_path):
     results = []
-    for root, dirs, files in scandir.walk(dir_path):
+    for root, dirs, files in os.walk(dir_path):
         files = remove_hidden_files(files)
         for file in files:
             file_path = os.path.join(root, file)
@@ -2447,7 +2458,7 @@ def similar(a, b):
     elif a == b:
         return 1.0
     else:
-        return SequenceMatcher(None, a, b).ratio()
+        return Indel.normalized_similarity(a, b)
 
 
 # Sets the modification date of the passed file path to the passed date.
@@ -2478,7 +2489,7 @@ def is_same_index_number(index_one, index_two, allow_array_match=False):
 def get_file_hash(file, is_internal=False, internal_file_name=None):
     try:
         BUF_SIZE = 65536  # 64KB buffer size (adjust as needed)
-        hash_obj = hashlib.sha256()
+        hash_obj = xxhash.xxh64()
 
         if is_internal:
             with zipfile.ZipFile(file) as zip:
@@ -3341,27 +3352,10 @@ def is_image_black_and_white(image, tolerance=15):
     try:
         # Convert the image to RGB (ensures consistent handling of image modes)
         image_rgb = image.convert("RGB")
-
-        # Extract pixel data
-        pixels = list(image_rgb.getdata())
-
-        # Count pixels that are grayscale and black/white
-        grayscale_count = 0
-
-        for r, g, b in pixels:
-            # Check if the pixel is grayscale within the tolerance
-            if abs(r - g) <= tolerance and abs(g - b) <= tolerance:
-                # Further check if it is black or white
-                if r == 0 or r == 255:
-                    grayscale_count += 1
-                elif 0 < r < 255:
-                    grayscale_count += 1
-
-        # If enough pixels are grayscale or black/white, return True
-        if grayscale_count / len(pixels) > 0.9:
-            return True
-
-        return False  # Otherwise, it's not black and white
+        r, g, b = image_rgb.split()
+        mean_rg = ImageStat.Stat(ImageChops.difference(r, g)).mean[0]
+        mean_gb = ImageStat.Stat(ImageChops.difference(g, b)).mean[0]
+        return mean_rg <= tolerance and mean_gb <= tolerance
     except Exception as e:
         send_message(f"Error checking if image is black and white: {e}", error=True)
         return False
@@ -5031,7 +5025,7 @@ def clean_str(
     s = remove_dual_space(s)
 
     # convert to ascii
-    s = convert_to_ascii(s) if not skip_convert_to_ascii else s
+    s = s.encode("ascii", "ignore").decode() if not skip_convert_to_ascii else s
 
     # Replace underscores with periods
     s = replace_underscores(s) if not skip_underscore and "_" in s else s
@@ -5057,7 +5051,7 @@ def create_folders_for_items_in_download_folder():
             continue
 
         try:
-            for root, dirs, files in scandir.walk(download_folder):
+            for root, dirs, files in os.walk(download_folder):
                 files, dirs = process_files_and_folders(
                     root,
                     files,
@@ -5202,19 +5196,14 @@ def create_folders_for_items_in_download_folder():
 
 
 # convert string to acsii
-@lru_cache(maxsize=3500)
-def convert_to_ascii(s):
-    return "".join(i for i in s if ord(i) < 128)
+
 
 
 # convert array to string separated by whatever is passed in the separator parameter
 def array_to_string(array, separator=", "):
     if isinstance(array, list):
-        return separator.join([str(x) for x in array])
-    elif isinstance(array, (int, float, str)):
-        return separator.join([str(array)])
-    else:
-        return str(array)
+        return separator.join(map(str, array))
+    return str(array)
 
 
 # Converts an array to a string seperated array with subsequent whole numbers abbreviated.
@@ -5685,8 +5674,6 @@ def remove_duplicates(items):
     return list(dict.fromkeys(items))
 
 
-# The signature for the End of Central Directory record.
-EOCD_SIGNATURE = b"\x50\x4b\x05\x06"
 
 
 # Return the zip comment for the passed zip file (cached)
@@ -5694,32 +5681,14 @@ EOCD_SIGNATURE = b"\x50\x4b\x05\x06"
 @lru_cache(maxsize=None)
 def get_zip_comment_cache(zip_file):
     """
-    Quickly reads a ZIP file's comment by reading only the end of the file.
+    Reads a ZIP file's comment using the stdlib zipfile module.
     """
     comment = ""
     try:
-        with open(zip_file, "rb") as f:
-            # Seek to the end of the file to get its size.
-            f.seek(0, os.SEEK_END)
-            file_size = f.tell()
-
-            # Read a buffer large enough for the max comment size + EOCD record.
-            buffer_size = min(file_size, 65535 + 22)
-            f.seek(file_size - buffer_size, os.SEEK_SET)
-            end_data = f.read()
-
-            # Search backwards for the EOCD signature.
-            sig_pos = end_data.rfind(EOCD_SIGNATURE)
-
-            if sig_pos > -1:
-                comment_len_pos = sig_pos + 20
-                comment_len = struct.unpack(
-                    "<H", end_data[comment_len_pos : comment_len_pos + 2]
-                )[0]
-                comment_pos = sig_pos + 22
-
-                if comment_len == len(end_data) - comment_pos:
-                    comment = end_data[comment_pos:].decode("utf-8")
+        with zipfile.ZipFile(zip_file, "r") as z:
+            raw = z.comment
+            if raw:
+                comment = raw.decode("utf-8")
     except Exception as e:
         send_message(
             f"\tFailed to get zip comment for: {zip_file} - Error: {e}", error=True
@@ -5731,32 +5700,14 @@ def get_zip_comment_cache(zip_file):
 # Used on downloaded files. (more likely to change, hence no cache)
 def get_zip_comment(zip_file):
     """
-    Quickly reads a ZIP file's comment by reading only the end of the file.
+    Reads a ZIP file's comment using the stdlib zipfile module.
     """
     comment = ""
     try:
-        with open(zip_file, "rb") as f:
-            # Seek to the end of the file to get its size.
-            f.seek(0, os.SEEK_END)
-            file_size = f.tell()
-
-            # Read a buffer large enough for the max comment size + EOCD record.
-            buffer_size = min(file_size, 65535 + 22)
-            f.seek(file_size - buffer_size, os.SEEK_SET)
-            end_data = f.read()
-
-            # Search backwards for the EOCD signature.
-            sig_pos = end_data.rfind(EOCD_SIGNATURE)
-
-            if sig_pos > -1:
-                comment_len_pos = sig_pos + 20
-                comment_len = struct.unpack(
-                    "<H", end_data[comment_len_pos : comment_len_pos + 2]
-                )[0]
-                comment_pos = sig_pos + 22
-
-                if comment_len == len(end_data) - comment_pos:
-                    comment = end_data[comment_pos:].decode("utf-8")
+        with zipfile.ZipFile(zip_file, "r") as z:
+            raw = z.comment
+            if raw:
+                comment = raw.decode("utf-8")
     except Exception as e:
         send_message(
             f"\tFailed to get zip comment for: {zip_file} - Error: {e}", error=True
@@ -5778,7 +5729,7 @@ def check_for_duplicate_volumes(paths_to_search=[]):
                 continue
 
             print(f"\nSearching {p} for duplicate releases...")
-            for root, dirs, files in scandir.walk(p):
+            for root, dirs, files in os.walk(p):
                 print(f"\t{root}")
                 files, dirs = process_files_and_folders(
                     root,
@@ -6768,7 +6719,7 @@ def check_for_existing_series(
                             os.chdir(path)
                             reorganized = False
 
-                            for root, dirs, files in scandir.walk(path):
+                            for root, dirs, files in os.walk(path):
                                 if (
                                     test_mode
                                     and cached_paths
@@ -7490,7 +7441,7 @@ def rename_dirs_in_download_folder(paths_to_process=download_folders):
                     transferred_dirs.append(create_folder_obj(new_folder_path_two))
             else:
                 # New folder exists, move files to it
-                for root, dirs, files in scandir.walk(root):
+                for root, dirs, files in os.walk(root):
                     folder_accessor_two = create_folder_obj(
                         root,
                         dirs,
@@ -7815,8 +7766,8 @@ def parse_comicinfo_xml(xml_file):
     tags = {}
     if xml_file:
         try:
-            tree = ET.fromstring(xml_file)
-            tags = {child.tag: child.text for child in tree}
+            parsed = xmltodict.parse(xml_file)
+            tags = dict(parsed.get("ComicInfo", {}))
         except Exception as e:
             send_message(
                 f"Attempted to parse comicinfo.xml: {xml_file}\nERROR: {e}",
@@ -7853,7 +7804,7 @@ def rename_files(
             )
             continue
 
-        for root, dirs, files in scandir.walk(path):
+        for root, dirs, files in os.walk(path):
             if test_mode:
                 if root not in download_folders:
                     return
@@ -8528,7 +8479,7 @@ def delete_chapters_from_downloads():
                 continue
 
             os.chdir(path)
-            for root, dirs, files in scandir.walk(path):
+            for root, dirs, files in os.walk(path):
                 files, dirs = process_files_and_folders(
                     root,
                     files,
@@ -8582,7 +8533,7 @@ def delete_chapters_from_downloads():
                                 grouped_notifications, Embed(embed, None)
                             )
                             remove_file(os.path.join(root, file))
-            for root, dirs, files in scandir.walk(path):
+            for root, dirs, files in os.walk(path):
                 files, dirs = process_files_and_folders(
                     root,
                     files,
@@ -8924,7 +8875,7 @@ def extract_covers(paths_to_process=paths):
         os.chdir(path)
 
         # Traverse the directory tree rooted at the path
-        for root, dirs, files in scandir.walk(path):
+        for root, dirs, files in os.walk(path):
             if watchdog_toggle:
                 if not moved_folder_names or (
                     clean_str(
@@ -9531,7 +9482,7 @@ def delete_unacceptable_files():
                 continue
 
             os.chdir(path)
-            for root, dirs, files in scandir.walk(path):
+            for root, dirs, files in os.walk(path):
                 files, dirs = process_files_and_folders(
                     root,
                     files,
@@ -9585,7 +9536,7 @@ def delete_unacceptable_files():
                             )
                             remove_file(file_path)
                             break
-            for root, dirs, files in scandir.walk(path):
+            for root, dirs, files in os.walk(path):
                 files, dirs = process_files_and_folders(
                     root,
                     files,
@@ -9658,37 +9609,50 @@ def get_session_object(url):
 
 # Makes a GET request to the given URL using a reusable session object,
 # and returns a BeautifulSoup object representing the parsed HTML response.
-def scrape_url(url, strainer=None, headers=None, cookies=None, proxy=None):
-    try:
-        session_object = get_session_object(url)
-
-        # Create a dictionary of request parameters with only non-None values
-        request_params = {
-            "url": url,
-            "headers": headers,
-            "cookies": cookies,
-            "proxies": proxy,
-            "timeout": 10,
-        }
-        response = session_object.get(
-            **{k: v for k, v in request_params.items() if v is not None}
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(sleep_timer_bk),
+    retry=retry_if_exception_type(requests.exceptions.RequestException),
+    retry_error_callback=lambda retry_state: (
+        send_message(
+            f"Error scraping URL: {retry_state.outcome.exception()}", error=True
         )
+        or None
+    ),
+    before_sleep=lambda retry_state: send_message(
+        f"Error scraping URL (retrying attempt "
+        f"{retry_state.attempt_number}): {retry_state.outcome.exception()}",
+        error=True,
+    ),
+)
+def scrape_url(url, strainer=None, headers=None, cookies=None, proxy=None):
+    session_object = get_session_object(url)
 
-        # Raise an exception if the status code indicates rate limiting
-        if response.status_code == 403:
-            raise Exception("Too many requests, we're being rate-limited!")
+    # Create a dictionary of request parameters with only non-None values
+    request_params = {
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "proxies": proxy,
+        "timeout": 10,
+    }
+    response = session_object.get(
+        **{k: v for k, v in request_params.items() if v is not None}
+    )
 
-        soup = None
-        if strainer:
-            # Use the strainer to parse only specific parts of the HTML document
-            soup = BeautifulSoup(response.content, "lxml", parse_only=strainer)
-        else:
-            soup = BeautifulSoup(response.content, "lxml")
+    # Raise a plain Exception (NOT a RequestException) so tenacity treats
+    # a 403 as a hard-block and re-raises immediately without retrying.
+    if response.status_code == 403:
+        raise Exception("Too many requests, we're being rate-limited!")
 
-        return soup
-    except requests.exceptions.RequestException as e:
-        send_message(f"Error scraping URL: {e}", error=True)
-        return None
+    soup = None
+    if strainer:
+        # Use the strainer to parse only specific parts of the HTML document
+        soup = BeautifulSoup(response.content, "lxml", parse_only=strainer)
+    else:
+        soup = BeautifulSoup(response.content, "lxml")
+
+    return soup
 
 
 # Groups all books with a matching title and book_type.
@@ -10784,7 +10748,7 @@ def cache_existing_library_paths(
         if os.path.exists(path):
             if path not in download_folders:
                 try:
-                    for root, dirs, files in scandir.walk(path):
+                    for root, dirs, files in os.walk(path):
                         if (root != path and root not in cached_paths) and (
                             not root.startswith(".") and not root.startswith("_")
                         ):
@@ -10839,13 +10803,8 @@ def scan_komga_library(library_id, library_name):
     try:
         request = requests.post(
             f"{komga_url}/api/v1/libraries/{library_id}/scan",
-            headers={
-                "Authorization": "Basic %s"
-                % b64encode(
-                    f"{komga_login_email}:{komga_login_password}".encode("utf-8")
-                ).decode("utf-8"),
-                "Accept": "*/*",
-            },
+            auth=HTTPBasicAuth(komga_login_email, komga_login_password),
+            headers={"Accept": "*/*"},
         )
         if request.status_code == 202:
             send_message(
@@ -10868,7 +10827,7 @@ def scan_komga_library(library_id, library_name):
 # Sends a GET library request to Komga for all libraries using
 # {komga_url}/api/v1/libraries
 # Requires komga settings to be set in settings.py
-def get_komga_libraries(first_run=True):
+def get_komga_libraries():
     results = []
 
     if not komga_ip:
@@ -10894,17 +10853,21 @@ def get_komga_libraries(first_run=True):
 
     komga_url = f"{komga_ip}:{komga_port}" if komga_port else komga_ip
 
-    try:
-        request = requests.get(
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(60),
+        retry=retry_if_exception(lambda e: "104" in str(e)),
+        reraise=True,
+    )
+    def _fetch():
+        return requests.get(
             f"{komga_url}/api/v1/libraries",
-            headers={
-                "Authorization": "Basic %s"
-                % b64encode(
-                    f"{komga_login_email}:{komga_login_password}".encode("utf-8")
-                ).decode("utf-8"),
-                "Accept": "*/*",
-            },
+            auth=HTTPBasicAuth(komga_login_email, komga_login_password),
+            headers={"Accept": "*/*"},
         )
+
+    try:
+        request = _fetch()
         if request.status_code == 200:
             results = request.json()
         else:
@@ -10915,15 +10878,10 @@ def get_komga_libraries(first_run=True):
                 error=True,
             )
     except Exception as e:
-        # if first, and error code 104, then try again after sleeping
-        if first_run and "104" in str(e):
-            time.sleep(60)
-            results = get_komga_libraries(first_run=False)
-        else:
-            send_message(
-                f"Failed to Get Komga Libraries, ERROR: {e}",
-                error=True,
-            )
+        send_message(
+            f"Failed to Get Komga Libraries, ERROR: {e}",
+            error=True,
+        )
     return results
 
 
@@ -11009,7 +10967,7 @@ def generate_rename_lists(skipped_release_group_files=[], skipped_publisher_file
                 continue
         try:
             # Walk the directory tree
-            for root, dirs, files in scandir.walk(path):
+            for root, dirs, files in os.walk(path):
                 if not files:
                     continue
 
@@ -11227,40 +11185,26 @@ class Image_Result:
 
 # Preps the image for comparison
 def preprocess_image(image):
-    # Check if the image is already grayscale
-    if len(image.shape) == 2 or (len(image.shape) == 3 and image.shape[2] == 1):
-        gray_image = image
-    else:
-        # Convert to grayscale if it's a color image
-        gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-
-    # Apply histogram equalization
-    gray_image = cv2.equalizeHist(gray_image)
-
-    # Normalize the image
-    gray_image = gray_image / 255.0
-
-    return gray_image
+    # Compute the perceptual hash (pHash) of a PIL Image.
+    # phash internally converts to grayscale and resizes, so no manual
+    # grayscale/normalization is required. Returns a 64-bit ImageHash.
+    return imagehash.phash(image)
 
 
 # Comapres two images using SSIM
 def compare_images(imageA, imageB, silent=False):
+    # imageA and imageB are imagehash.ImageHash objects (64-bit pHash).
+    # Similarity is derived from the Hamming distance so that the result
+    # stays in the 0..1 range, keeping the existing thresholds meaningful.
     try:
-        if not silent:
-            print(f"\t\t\tBlank Image Size: {imageA.shape}")
-            print(f"\t\t\tInternal Cover Size: {imageB.shape}")
-
-        # Preprocess images
-        grayA = preprocess_image(imageA)
-        grayB = preprocess_image(imageB)
-
-        # Compute SSIM between the two images
-        ssim_score = ssim(grayA, grayB, data_range=1.0)
+        hamming_distance = imageA - imageB
+        similarity_score = 1 - (hamming_distance / 64.0)
 
         if not silent:
-            print(f"\t\t\t\tSSIM: {ssim_score}")
+            print(f"\t\t\t\tHamming Distance: {hamming_distance}")
+            print(f"\t\t\t\tSimilarity: {similarity_score}")
 
-        return ssim_score
+        return similarity_score
     except Exception as e:
         send_message(str(e), error=True)
         return 0
@@ -11270,56 +11214,26 @@ def compare_images(imageA, imageB, silent=False):
 def prep_images_for_similarity(
     blank_image_path, internal_cover_data, both_cover_data=False, silent=False
 ):
-
-    def resize_images(img1, img2, desired_width=400, desired_height=600):
-        img1_resized = cv2.resize(
-            img1, (desired_width, desired_height), interpolation=cv2.INTER_AREA
-        )
-        img2_resized = cv2.resize(
-            img2, (desired_width, desired_height), interpolation=cv2.INTER_AREA
-        )
-        return img1_resized, img2_resized
-
-    def match_image_channels(img1, img2):
-        if len(img1.shape) == 3 and len(img2.shape) == 3:
-            min_channels = min(img1.shape[2], img2.shape[2])
-            img1, img2 = img1[:, :, :min_channels], img2[:, :, :min_channels]
-        elif len(img1.shape) == 3 and len(img2.shape) == 2:
-            img1 = img1[:, :, 0]
-        elif len(img1.shape) == 2 and len(img2.shape) == 3:
-            img2 = img2[:, :, 0]
-        return img1, img2
-
-    # Decode internal cover data
-    internal_cover = cv2.imdecode(
-        np.frombuffer(internal_cover_data, np.uint8), cv2.IMREAD_UNCHANGED
+    # Hash the internal cover (always raw image bytes).
+    internal_cover_hash = preprocess_image(
+        Image.open(io.BytesIO(internal_cover_data))
     )
 
-    # Load blank image either from path or data buffer based on condition
-    blank_image = (
-        cv2.imread(blank_image_path)
-        if not both_cover_data
-        else cv2.imdecode(
-            np.frombuffer(blank_image_path, np.uint8), cv2.IMREAD_UNCHANGED
+    # Determine the hash of the "blank"/reference image.
+    if both_cover_data:
+        # blank_image_path is actually raw image bytes in this mode.
+        blank_image_hash = preprocess_image(
+            Image.open(io.BytesIO(blank_image_path))
         )
-    )
-    internal_cover = np.array(internal_cover)
+    elif blank_image_path == blank_white_image_path and blank_white_image_hash:
+        blank_image_hash = blank_white_image_hash
+    elif blank_image_path == blank_black_image_path and blank_black_image_hash:
+        blank_image_hash = blank_black_image_hash
+    else:
+        blank_image_hash = preprocess_image(Image.open(blank_image_path))
 
-    # Resize both images to 600x400
-    blank_image, internal_cover = resize_images(blank_image, internal_cover)
-
-    # Ensure both images have the same number of color channels
-    blank_image, internal_cover = match_image_channels(blank_image, internal_cover)
-
-    # Ensure both images are in the same format (grayscale or color)
-    if len(blank_image.shape) != len(internal_cover.shape):
-        if len(blank_image.shape) == 3:
-            blank_image = cv2.cvtColor(blank_image, cv2.COLOR_BGR2GRAY)
-        else:
-            internal_cover = cv2.cvtColor(internal_cover, cv2.COLOR_BGR2GRAY)
-
-    # Compare images and return similarity score
-    score = compare_images(blank_image, internal_cover, silent=silent)
+    # Compare hashes and return the similarity score (0..1).
+    score = compare_images(blank_image_hash, internal_cover_hash, silent=silent)
 
     return score
 
@@ -11346,7 +11260,7 @@ def compress(temp_dir, cbz_filename):
     successfull = False
     try:
         with zipfile.ZipFile(cbz_filename, "w") as zip:
-            for root, dirs, files in scandir.walk(temp_dir):
+            for root, dirs, files in os.walk(temp_dir):
                 for file in files:
                     zip.write(
                         os.path.join(root, file),
@@ -11374,7 +11288,7 @@ def convert_to_cbz():
             continue
 
         print(f"\t{folder}")
-        for root, dirs, files in scandir.walk(folder):
+        for root, dirs, files in os.walk(folder):
             files, dirs = process_files_and_folders(
                 root,
                 files,
@@ -11461,7 +11375,7 @@ def convert_to_cbz():
 
                         # Get hashes of all files in archive
                         hashes = []
-                        for root2, dirs2, files2 in scandir.walk(temp_dir):
+                        for root2, dirs2, files2 in os.walk(temp_dir):
                             for file2 in files2:
                                 path = os.path.join(root2, file2)
                                 hashes.append(get_file_hash(path))
@@ -11654,7 +11568,7 @@ def correct_file_extensions():
             continue
 
         print(f"\t{folder}")
-        for root, dirs, files in scandir.walk(folder):
+        for root, dirs, files in os.walk(folder):
             files, dirs = process_files_and_folders(
                 root,
                 files,
@@ -11752,7 +11666,7 @@ def move_series_to_correct_library(paths_to_search=paths_with_types):
                     continue
 
                 print(f"\nSearching {p.path} for incorrectly matching series types...")
-                for root, dirs, files in scandir.walk(p.path):
+                for root, dirs, files in os.walk(p.path):
                     print(f"\t{root}")
 
                     files, dirs = process_files_and_folders(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+# pyproject.toml — pytest characterization safety-net configuration.
+#
+# This file ONLY configures the new pytest suite under tests/. It deliberately
+# does NOT declare the project's runtime build (the app ships as a single script
+# + requirements.txt + Dockerfile, unchanged). The legacy custom runner
+# `python3 tests.py` and the Docker/CI pipeline are untouched by this file.
+#
+# Dev setup:
+#   uv venv --python 3.13 .venv
+#   uv pip install -r requirements.txt
+#   uv pip install -r requirements-dev.txt   # pytest
+#   .venv/bin/pytest -q
+
+[tool.pytest.ini_options]
+# Only collect the new suite. tests.py (the legacy bespoke runner) lives at repo
+# root and is never auto-collected because testpaths is pinned to tests/.
+testpaths = ["tests"]
+# Make the repo root importable (`import komga_cover_extractor` / `settings`) AND
+# the tests/ dir importable for shared helpers (`from _kce_support import ...`,
+# `from regression_gate import ...`). tests/ is deliberately NOT a package (no
+# __init__.py) so `import tests` still resolves to the legacy tests.py runner.
+pythonpath = [".", "tests"]
+# importlib mode: no __init__.py needed, and test files with duplicate basenames
+# across subdirectories (tests/parsing/, tests/utils/, ...) don't collide.
+addopts = "-ra --tb=short --strict-markers --import-mode=importlib"
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+markers = [
+    "slow: tests that do real image hashing / heavier I/O",
+    "external: tests that exercise Komga/Bookwalker/Discord code paths via mocks",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+# Development-only dependencies (NOT needed to run the app or the Docker image).
+# Install with:  uv pip install -r requirements-dev.txt
+#
+# The pytest characterization safety net under tests/ uses only pytest itself
+# plus the runtime deps already in requirements.txt (Pillow, imagehash, xxhash,
+# xmltodict, regex, ...). No extra plugins are required: network is stubbed with
+# the stdlib-friendly monkeypatch fixture, archives are built with stdlib zipfile.
+pytest>=8,<10

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,9 @@ charset-normalizer==3.4.4
 discord-webhook==1.4.1
 filetype==1.2.0
 idna==3.11
-imageio==2.37.0
 inflate64==1.0.3
-lazy_loader==0.4
 lxml==6.0.2
 multivolumefile==0.2.3
-networkx==3.4.2
 numpy==2.2.6
 packaging==25.0
 pillow==12.0.0
@@ -31,7 +28,6 @@ imagehash==4.3.2
 scipy==1.15.3
 soupsieve==2.8
 texttable==1.7.0
-tifffile==2025.5.10
 titlecase==2.4.1
 typing_extensions==4.15.0
 Unidecode==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ lxml==6.0.2
 multivolumefile==0.2.3
 networkx==3.4.2
 numpy==2.2.6
-opencv-python-headless==4.12.0.88
 packaging==25.0
 pillow==12.0.0
 psutil==7.1.0
@@ -24,8 +23,11 @@ pyzstd==0.18.0
 rarfile==4.2
 regex==2025.9.18
 requests==2.32.5
-scandir==1.10.0
-scikit-image==0.25.2
+rapidfuzz==3.14.5
+tenacity==9.1.4
+xxhash==3.7.0
+xmltodict==1.0.4
+imagehash==4.3.2
 scipy==1.15.3
 soupsieve==2.8
 texttable==1.7.0

--- a/tests/_kce_support.py
+++ b/tests/_kce_support.py
@@ -1,0 +1,55 @@
+"""Shared, non-fixture helpers for the characterization suite.
+
+Kept in a uniquely-named module (NOT ``__init__.py``) on purpose: the suite
+directory must stay package-free so that ``import tests`` keeps resolving to the
+legacy ``tests.py`` runner at repo root (a regular module wins over a namespace
+directory, but a ``tests/__init__.py`` package would shadow it and break both
+the regression gate and the documented ``python3 -c "import tests; ..."`` dev
+workflow). Tests import these via ``from _kce_support import ...`` thanks to
+``pythonpath = ["tests"]`` in pyproject.toml.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+
+import komga_cover_extractor as kce
+
+# Repo root = parent of this tests/ directory.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Plain-data attribute types we snapshot/restore for global isolation. Compiled
+# regexes, functions, classes and modules are intentionally excluded.
+SNAPSHOT_TYPES = (list, dict, set, tuple, str, bytes, int, float, bool, type(None))
+
+
+def lru_cached_callables():
+    """Every module-level callable carrying an lru_cache (runtime-introspected)."""
+    out = []
+    for name in dir(kce):
+        try:
+            obj = getattr(kce, name)
+        except Exception:
+            continue
+        if callable(obj) and hasattr(obj, "cache_clear"):
+            out.append(obj)
+    return out
+
+
+def clear_all_caches():
+    """Clear every lru_cache on the module (used before and after each test)."""
+    for fn in lru_cached_callables():
+        try:
+            fn.cache_clear()
+        except Exception:
+            pass
+
+
+def real_jpeg_bytes(color=(220, 50, 50), size=(2, 2)) -> bytes:
+    """A genuinely-decodable JPEG so Image.open() paths never raise on fixtures."""
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, format="JPEG")
+    return buf.getvalue()

--- a/tests/archive/test_comic_info.py
+++ b/tests/archive/test_comic_info.py
@@ -1,0 +1,290 @@
+"""Characterization tests for contains_comic_info (lru_cached) and
+parse_comicinfo_xml (xmltodict-backed).
+
+Design notes
+------------
+* All return values are pinned from *actual* function invocations observed via
+  the .venv interpreter.  Where the current behaviour is surprising, a
+  ``# FLAG:`` comment is attached.
+* ``isolated_globals`` (autouse) clears every lru_cache before and after each
+  test, so cache-persistence tests that intentionally *keep* the cache warm use
+  an explicit call sequence within the same test body.
+* ``parse_comicinfo_xml`` takes a raw XML *string* (not a path, not a file
+  object) and delegates to ``xmltodict.parse``.
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# contains_comic_info
+# ---------------------------------------------------------------------------
+
+class TestContainsComicInfo:
+    """Pin the behaviour of the lru_cached contains_comic_info function."""
+
+    def test_archive_with_comicinfo_xml_returns_true(self, cbz_factory, comicinfo_xml):
+        """A cbz that contains ComicInfo.xml at the root → True."""
+        path = cbz_factory(comicinfo_xml=comicinfo_xml(Title="T"))
+        assert kce.contains_comic_info(str(path)) is True
+
+    def test_archive_without_comicinfo_xml_returns_false(self, cbz_factory):
+        """A cbz that has only image pages and no ComicInfo.xml → False."""
+        path = cbz_factory()  # default: single page_001.jpg, no ComicInfo
+        assert kce.contains_comic_info(str(path)) is False
+
+    def test_lowercase_comicinfo_xml_returns_true(self, cbz_factory):
+        """The check is case-insensitive: 'comicinfo.xml' (all lower) → True."""
+        path = cbz_factory(entries={
+            "page_001.jpg": b"FAKE",
+            "comicinfo.xml": "<ComicInfo><Title>T</Title></ComicInfo>",
+        })
+        assert kce.contains_comic_info(str(path)) is True
+
+    def test_uppercase_comicinfo_xml_returns_true(self, cbz_factory):
+        """The check is case-insensitive: 'COMICINFO.XML' (all upper) → True."""
+        path = cbz_factory(entries={
+            "page_001.jpg": b"FAKE",
+            "COMICINFO.XML": "<ComicInfo><Title>T</Title></ComicInfo>",
+        })
+        assert kce.contains_comic_info(str(path)) is True
+
+    def test_corrupt_non_zip_file_returns_false(self, tmp_path):
+        """A file that is not a valid zip (BadZipFile) → False (exception swallowed)."""
+        corrupt = tmp_path / "corrupt.cbz"
+        corrupt.write_bytes(b"NOT A ZIP FILE AT ALL")
+        # FLAG: BadZipFile is caught and silently returns False (after logging).
+        result = kce.contains_comic_info(str(corrupt))
+        assert result is False
+
+    def test_missing_file_path_returns_false(self):
+        """A path that does not exist on disk → False (FileNotFoundError swallowed)."""
+        # FLAG: FileNotFoundError is caught and silently returns False (after logging).
+        result = kce.contains_comic_info("/nonexistent/path/to/archive.cbz")
+        assert result is False
+
+    def test_return_type_is_bool_when_true(self, cbz_factory, comicinfo_xml):
+        """Return value is a Python bool (True), not just truthy."""
+        path = cbz_factory(comicinfo_xml=comicinfo_xml(Title="T"))
+        result = kce.contains_comic_info(str(path))
+        assert result is True
+        assert type(result) is bool
+
+    def test_return_type_is_bool_when_false(self, cbz_factory):
+        """Return value is a Python bool (False), not just falsy."""
+        path = cbz_factory()
+        result = kce.contains_comic_info(str(path))
+        assert result is False
+        assert type(result) is bool
+
+    def test_lru_cache_serves_stale_result(self, tmp_path):
+        """lru_cache means the result is memoised by path string.
+
+        If the archive is overwritten *after* the first call, the cached (stale)
+        value is returned.  This is the expected, pinned behaviour of the cache.
+        """
+        archive = tmp_path / "vol.cbz"
+
+        # First: write an archive WITHOUT ComicInfo.xml → cached as False.
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("page_001.jpg", b"FAKE")
+        first = kce.contains_comic_info(str(archive))
+        assert first is False
+
+        # Overwrite in-place WITH ComicInfo.xml; cache is NOT cleared between calls.
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("page_001.jpg", b"FAKE")
+            zf.writestr("ComicInfo.xml", "<ComicInfo><Title>T</Title></ComicInfo>")
+        second = kce.contains_comic_info(str(archive))
+        # FLAG: stale cache hit — reports False even though the file now has ComicInfo.xml.
+        assert second is False
+
+    def test_mixed_casing_entry_alongside_page(self, cbz_factory):
+        """ComicInfo.xml mixed case alongside image pages is detected."""
+        path = cbz_factory(
+            entries={
+                "page_001.jpg": b"FAKE",
+                "page_002.jpg": b"FAKE",
+                "CoMiCiNfO.XmL": "<ComicInfo><Title>T</Title></ComicInfo>",
+            }
+        )
+        assert kce.contains_comic_info(str(path)) is True
+
+
+# ---------------------------------------------------------------------------
+# parse_comicinfo_xml
+# ---------------------------------------------------------------------------
+
+class TestParseComicInfoXml:
+    """Pin the behaviour of parse_comicinfo_xml, which takes a raw XML string."""
+
+    def test_valid_xml_returns_dict(self, comicinfo_xml):
+        """A well-formed ComicInfo.xml string returns a plain dict."""
+        xml = comicinfo_xml(Title="T", Volume="3")
+        result = kce.parse_comicinfo_xml(xml)
+        assert isinstance(result, dict)
+
+    def test_valid_xml_title_and_volume_exact_structure(self, comicinfo_xml):
+        """Exact keys and string values for a two-field ComicInfo XML.
+
+        The conftest ``comicinfo_xml`` fixture emits namespace attributes, so
+        xmltodict surfaces them as '@xmlns:xsi' and '@xmlns:xsd' keys in
+        addition to the field keys.  All leaf values are strings, not ints.
+        """
+        xml = comicinfo_xml(Title="T", Volume="3")
+        result = kce.parse_comicinfo_xml(xml)
+        assert result["Title"] == "T"
+        assert result["Volume"] == "3"           # volume is a string, not int
+        assert result["@xmlns:xsi"] == "http://www.w3.org/2001/XMLSchema-instance"
+        assert result["@xmlns:xsd"] == "http://www.w3.org/2001/XMLSchema"
+
+    def test_valid_xml_keys_are_exact_set(self, comicinfo_xml):
+        """The returned dict has exactly the keys produced by xmltodict — no extras."""
+        xml = comicinfo_xml(Title="T", Volume="3")
+        result = kce.parse_comicinfo_xml(xml)
+        expected_keys = {"@xmlns:xsi", "@xmlns:xsd", "Title", "Volume"}
+        assert set(result.keys()) == expected_keys
+
+    def test_minimal_xml_no_ns_attrs(self):
+        """Without namespace declarations, no '@xmlns:*' keys appear in result."""
+        xml = "<ComicInfo><Title>T</Title><Volume>3</Volume></ComicInfo>"
+        result = kce.parse_comicinfo_xml(xml)
+        assert result == {"Title": "T", "Volume": "3"}
+
+    def test_volume_value_is_string_not_int(self):
+        """xmltodict returns ALL leaf values as strings (no type coercion)."""
+        xml = "<ComicInfo><Volume>5</Volume></ComicInfo>"
+        result = kce.parse_comicinfo_xml(xml)
+        assert result["Volume"] == "5"
+        assert type(result["Volume"]) is str
+
+    def test_malformed_xml_returns_empty_dict(self):
+        """Malformed / invalid XML → {} (exception caught, empty dict returned)."""
+        # FLAG: parse errors are swallowed; caller receives {} rather than an exception.
+        result = kce.parse_comicinfo_xml("<ComicInfo><Title>T</ComicInfo BROKEN")
+        assert result == {}
+
+    def test_none_input_returns_empty_dict(self):
+        """None → {} (the ``if xml_file:`` guard short-circuits before xmltodict)."""
+        result = kce.parse_comicinfo_xml(None)
+        assert result == {}
+
+    def test_empty_string_returns_empty_dict(self):
+        """Empty string '' → {} (falsy, so guard short-circuits)."""
+        result = kce.parse_comicinfo_xml("")
+        assert result == {}
+
+    def test_false_returns_empty_dict(self):
+        """Boolean False → {} (falsy, guard short-circuits)."""
+        result = kce.parse_comicinfo_xml(False)
+        assert result == {}
+
+    def test_zero_returns_empty_dict(self):
+        """Integer 0 → {} (falsy, guard short-circuits)."""
+        result = kce.parse_comicinfo_xml(0)
+        assert result == {}
+
+    def test_whitespace_string_returns_empty_dict(self):
+        """Whitespace-only string is truthy so xmltodict IS called → parse error → {}.
+
+        FLAG: unlike empty string, '   ' passes the truthiness check and reaches
+        xmltodict.parse, which raises 'no element found'; that exception is caught
+        and {} is returned.
+        """
+        result = kce.parse_comicinfo_xml("   ")
+        assert result == {}
+
+    def test_no_comicinfo_root_returns_empty_dict(self):
+        """Well-formed XML but with a different root element → {} (no 'ComicInfo' key)."""
+        result = kce.parse_comicinfo_xml("<Root><Title>T</Title></Root>")
+        assert result == {}
+
+    def test_empty_comicinfo_root_with_ns(self):
+        """ComicInfo element with no child tags but namespace attrs → dict with ns keys only."""
+        xml = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<ComicInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+            ' xmlns:xsd="http://www.w3.org/2001/XMLSchema">'
+            "</ComicInfo>"
+        )
+        result = kce.parse_comicinfo_xml(xml)
+        assert result == {
+            "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+            "@xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+        }
+
+    def test_empty_tag_value_is_none(self):
+        """An empty child element (``<Title/>``) → None value in the dict.
+
+        FLAG: xmltodict represents empty tags as None, not as empty string ''.
+        """
+        xml = "<ComicInfo><Title></Title><Volume>3</Volume></ComicInfo>"
+        result = kce.parse_comicinfo_xml(xml)
+        assert result["Title"] is None          # FLAG: empty tag → None, not ''
+        assert result["Volume"] == "3"
+
+    def test_multiple_fields_returned_intact(self, comicinfo_xml):
+        """All provided fields survive round-trip through xmltodict."""
+        xml = comicinfo_xml(Title="My Title", Volume="3", Year="2020", Publisher="Viz")
+        result = kce.parse_comicinfo_xml(xml)
+        assert result["Title"] == "My Title"
+        assert result["Volume"] == "3"
+        assert result["Year"] == "2020"
+        assert result["Publisher"] == "Viz"
+
+    def test_return_type_is_dict_on_success(self):
+        """The successful path returns a plain dict, not an OrderedDict or subclass."""
+        xml = "<ComicInfo><Title>T</Title></ComicInfo>"
+        result = kce.parse_comicinfo_xml(xml)
+        assert type(result) is dict
+
+    def test_return_type_is_dict_on_failure(self):
+        """The error path also returns a plain dict ({})."""
+        result = kce.parse_comicinfo_xml(None)
+        assert type(result) is dict
+
+    def test_integer_truthy_input_returns_empty_dict(self):
+        """A truthy non-string (int 42) reaches xmltodict → TypeError caught → {}.
+
+        FLAG: the guard only checks truthiness, not type; any truthy non-string
+        value causes xmltodict to raise, which is silently caught.
+        """
+        result = kce.parse_comicinfo_xml(42)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration: contains_comic_info + parse_comicinfo_xml together
+# ---------------------------------------------------------------------------
+
+class TestComicInfoIntegration:
+    """Verify the typical call sequence: detect presence, then parse content."""
+
+    def test_detect_then_parse_full_round_trip(self, cbz_factory, comicinfo_xml):
+        """If contains_comic_info is True, the XML content can be parsed directly."""
+        xml_str = comicinfo_xml(Title="RoundTrip", Volume="7")
+        path = cbz_factory(comicinfo_xml=xml_str)
+
+        assert kce.contains_comic_info(str(path)) is True
+
+        # Read the stored XML back out and parse it (simulating what the production
+        # code does: open the zip, read 'ComicInfo.xml', feed it to parse_comicinfo_xml).
+        import zipfile as _zf
+        with _zf.ZipFile(str(path)) as z:
+            # The entry was stored as 'ComicInfo.xml' by the fixture.
+            xml_content = z.read("ComicInfo.xml").decode("utf-8")
+
+        parsed = kce.parse_comicinfo_xml(xml_content)
+        assert parsed["Title"] == "RoundTrip"
+        assert parsed["Volume"] == "7"
+
+    def test_detect_false_no_parse_needed(self, cbz_factory):
+        """Archives without ComicInfo.xml: detect returns False, no parse needed."""
+        path = cbz_factory()
+        assert kce.contains_comic_info(str(path)) is False

--- a/tests/archive/test_file_from_zip.py
+++ b/tests/archive/test_file_from_zip.py
@@ -1,0 +1,405 @@
+"""Characterization tests for get_file_from_zip and count_images_in_cbz.
+
+get_file_from_zip(zip_file, searches, extension=None, allow_base=True)
+  - Reads a member out of a ZIP archive and returns its raw bytes, or None when
+    nothing matches.
+  - ``searches`` is a list of strings; each is first tried as a plain substring,
+    then as a regex (via re.search with IGNORECASE) against either:
+      * the basename of each file  (allow_base=True, default)
+      * the directory portion of each path  (allow_base=False)
+  - ``extension`` filters the member list before searching; pass a string like
+    ``'.xml'``.
+  - FLAG: extension=None raises TypeError because the list comprehension evaluates
+    ``item.endswith(None)`` before reaching the ``or not extension`` short-circuit.
+  - Swallows BadZipFile and FileNotFoundError, printing via send_message, and
+    returns None.
+
+count_images_in_cbz(file_path)
+  - Returns the int count of members whose names end with any extension in
+    image_extensions  {'.jpg', '.jpeg', '.png', '.tbn', '.webp'}.
+  - Swallows BadZipFile, prints via send_message, and returns 0.
+  - FileNotFoundError propagates (not caught internally).
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_bad_zip(tmp_path, name="bad.cbz"):
+    """Write non-ZIP bytes to a file; useful for BadZipFile tests."""
+    p = tmp_path / name
+    p.write_bytes(b"this is not a zip file!")
+    return p
+
+
+# ===========================================================================
+# get_file_from_zip
+# ===========================================================================
+
+class TestGetFileFromZip:
+    """Pin return type, matching logic, filtering, and error handling."""
+
+    # --- return type ---------------------------------------------------------
+
+    def test_returns_bytes_on_match(self, cbz_factory):
+        """A successful match returns bytes (the raw file content), not a str."""
+        path = cbz_factory(
+            entries={
+                "ComicInfo.xml": "<ComicInfo/>",
+                "page_001.jpg": b"\xff\xd8\xff",
+            }
+        )
+        result = kce.get_file_from_zip(str(path), ["ComicInfo.xml"], extension=".xml")
+        assert isinstance(result, bytes)
+
+    def test_content_matches_stored_bytes(self, cbz_factory):
+        """The bytes returned exactly equal what was stored in the archive."""
+        xml_content = b"<ComicInfo/>"
+        path = cbz_factory(entries={"ComicInfo.xml": xml_content})
+        result = kce.get_file_from_zip(str(path), ["ComicInfo.xml"], extension=".xml")
+        assert result == xml_content
+
+    # --- substring matching --------------------------------------------------
+
+    def test_substring_match_case_insensitive(self, cbz_factory):
+        """'comicinfo' (lowercase) matches 'ComicInfo.xml' basename."""
+        path = cbz_factory(entries={"ComicInfo.xml": b"<x/>"})
+        result = kce.get_file_from_zip(str(path), ["comicinfo"], extension=".xml")
+        assert result == b"<x/>"
+
+    def test_uppercase_search_matches_lowercase_filename(self, cbz_factory):
+        """Search term is case-folded before comparison — uppercase works too."""
+        path = cbz_factory(entries={"ComicInfo.xml": b"<x/>"})
+        result = kce.get_file_from_zip(str(path), ["COMICINFO"], extension=".xml")
+        assert result == b"<x/>"
+
+    def test_partial_substring_match(self, cbz_factory):
+        """'comic' is a partial match for 'comicinfo.xml' basename."""
+        path = cbz_factory(entries={"ComicInfo.xml": b"<partial/>"})
+        result = kce.get_file_from_zip(str(path), ["comic"], extension=".xml")
+        assert result == b"<partial/>"
+
+    def test_multiple_searches_first_term_wins(self, cbz_factory, jpeg_bytes):
+        """With two search terms the first-matched file in the zip order is returned."""
+        path = cbz_factory(
+            entries={
+                "ComicInfo.xml": b"<x/>",
+                "page_001.jpg": jpeg_bytes(),
+            }
+        )
+        # "comicinfo" should match ComicInfo.xml first (first in zip order)
+        result = kce.get_file_from_zip(
+            str(path), ["comicinfo", "page"], extension=".xml"
+        )
+        assert result == b"<x/>"
+
+    # --- regex matching ------------------------------------------------------
+
+    def test_regex_pattern_matches_when_substring_fails(self, cbz_factory, jpeg_bytes):
+        r"""A regex pattern like r'page_\d+' matches 'page_001.jpg'."""
+        path = cbz_factory(entries={"page_001.jpg": jpeg_bytes()})
+        result = kce.get_file_from_zip(
+            str(path), [r"page_\d+"], extension=".jpg"
+        )
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_regex_case_insensitive(self, cbz_factory, jpeg_bytes):
+        """Regex search uses re.IGNORECASE — uppercase pattern matches lowercase name."""
+        path = cbz_factory(entries={"page_001.jpg": jpeg_bytes()})
+        result = kce.get_file_from_zip(
+            str(path), [r"PAGE_\d+"], extension=".jpg"
+        )
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    # --- extension filtering -------------------------------------------------
+
+    def test_extension_filters_out_non_matching_files(self, cbz_factory, jpeg_bytes):
+        """Searching 'page' with extension='.xml' finds nothing (only JPG pages exist)."""
+        path = cbz_factory(entries={"page_001.jpg": jpeg_bytes()})
+        result = kce.get_file_from_zip(str(path), ["page"], extension=".xml")
+        assert result is None
+
+    def test_extension_jpg_finds_jpg_page(self, cbz_factory, jpeg_bytes):
+        """Searching 'page_001' with extension='.jpg' returns the JPEG bytes."""
+        jbytes = jpeg_bytes()
+        path = cbz_factory(entries={"page_001.jpg": jbytes, "ComicInfo.xml": b"<x/>"})
+        result = kce.get_file_from_zip(str(path), ["page_001"], extension=".jpg")
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_extension_empty_string_matches_all_files(self, cbz_factory, jpeg_bytes):
+        """extension='' matches all members (every filename ends with '').
+
+        FLAG: passing extension='' is NOT the same as extension=None — empty string
+        matches every member, whereas None raises TypeError.
+        """
+        path = cbz_factory(
+            entries={
+                "ComicInfo.xml": b"<x/>",
+                "page_001.jpg": jpeg_bytes(),
+            }
+        )
+        result = kce.get_file_from_zip(str(path), ["page"], extension="")
+        # 'page' matches 'page_001.jpg' (first in file_list that satisfies the search)
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_extension_none_raises_type_error(self, cbz_factory):
+        """extension=None triggers TypeError from item.endswith(None).
+
+        FLAG: the intended default 'match all' behaviour does not work because
+        Python evaluates item.endswith(None) before 'or not extension'.
+        """
+        path = cbz_factory(entries={"page_001.jpg": b"\xff\xd8"})
+        with pytest.raises(TypeError):
+            kce.get_file_from_zip(str(path), ["page"], extension=None)
+
+    # --- allow_base flag -----------------------------------------------------
+
+    def test_allow_base_true_searches_basename(self, cbz_factory, jpeg_bytes):
+        """allow_base=True (default): search term is matched against the filename only."""
+        path = cbz_factory(
+            entries={
+                "page_001.jpg": jpeg_bytes(),
+                "sub/page_002.jpg": jpeg_bytes(),
+            }
+        )
+        # 'sub' is a directory name, not a basename — should NOT match when allow_base=True
+        result = kce.get_file_from_zip(str(path), ["sub"], extension=".jpg", allow_base=True)
+        assert result is None  # FLAG: 'sub' not found in any basename
+
+    def test_allow_base_false_searches_directory_portion(self, cbz_factory, jpeg_bytes):
+        """allow_base=False: search term is matched against the directory portion of the path."""
+        path = cbz_factory(
+            entries={
+                "page_001.jpg": jpeg_bytes(),
+                "sub/page_002.jpg": jpeg_bytes(),
+            }
+        )
+        # 'sub' matches the directory portion 'sub/' of 'sub/page_002.jpg'
+        result = kce.get_file_from_zip(str(path), ["sub"], extension=".jpg", allow_base=False)
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_allow_base_false_root_file_falls_back_to_full_path(self, cbz_factory):
+        """allow_base=False on a root-level file: directory portion is '', so falls back to full path.
+
+        FLAG: when path.replace(basename, '') == '', mod_file_name falls back to
+        path.lower() (the full path), not just the directory. This means a root-level
+        'ComicInfo.xml' CAN be found by 'comicinfo' even with allow_base=False.
+        """
+        path = cbz_factory(entries={"ComicInfo.xml": b"<root/>"})
+        result = kce.get_file_from_zip(
+            str(path), ["comicinfo"], extension=".xml", allow_base=False
+        )
+        # FLAG: root-level file with no directory falls back to full path match
+        assert result == b"<root/>"
+
+    # --- not-found / sentinel values -----------------------------------------
+
+    def test_not_found_returns_none(self, cbz_factory, jpeg_bytes):
+        """No member matches -> return value is exactly None (not '' or False)."""
+        path = cbz_factory(entries={"page_001.jpg": jpeg_bytes()})
+        result = kce.get_file_from_zip(str(path), ["nonexistent"], extension=".jpg")
+        assert result is None
+
+    def test_empty_zip_after_extension_filter_returns_none(self, cbz_factory):
+        """If extension filter leaves no members, None is returned immediately."""
+        path = cbz_factory(entries={"ComicInfo.xml": b"<x/>"})
+        result = kce.get_file_from_zip(str(path), ["comicinfo"], extension=".jpg")
+        assert result is None
+
+    # --- error handling: bad zip / missing file ------------------------------
+
+    def test_missing_file_returns_none(self, tmp_path):
+        """FileNotFoundError is caught; None is returned (not raised).
+
+        FLAG: the function swallows FileNotFoundError and returns None.
+        """
+        result = kce.get_file_from_zip(
+            str(tmp_path / "nonexistent.cbz"), ["test"], extension=".xml"
+        )
+        assert result is None
+
+    def test_bad_zip_file_returns_none(self, tmp_path):
+        """BadZipFile is caught; None is returned (not raised).
+
+        FLAG: the function swallows BadZipFile and returns None.
+        """
+        bad = _make_bad_zip(tmp_path)
+        result = kce.get_file_from_zip(str(bad), ["test"], extension=".xml")
+        assert result is None
+
+    # --- subfolder entries ---------------------------------------------------
+
+    def test_entries_with_comicinfo_and_subdir_pages(self, cbz_factory, jpeg_bytes):
+        """Archives with mixed root + subdir entries work correctly."""
+        jbytes = jpeg_bytes()
+        path = cbz_factory(
+            entries={
+                "ComicInfo.xml": b"<ComicInfo/>",
+                "page_001.jpg": jbytes,
+                "sub/page_002.jpg": jbytes,
+            }
+        )
+        xml_result = kce.get_file_from_zip(
+            str(path), ["ComicInfo.xml"], extension=".xml"
+        )
+        assert xml_result == b"<ComicInfo/>"
+
+        jpg_result = kce.get_file_from_zip(
+            str(path), ["page_001"], extension=".jpg"
+        )
+        assert isinstance(jpg_result, bytes)
+        assert len(jpg_result) > 0
+
+    def test_path_object_accepted(self, cbz_factory):
+        """Passing a pathlib.Path (not str) is accepted by zipfile.ZipFile."""
+        path = cbz_factory(entries={"ComicInfo.xml": b"<x/>"})
+        # Pass Path directly (not str)
+        result = kce.get_file_from_zip(path, ["comicinfo"], extension=".xml")
+        assert result == b"<x/>"
+
+
+# ===========================================================================
+# count_images_in_cbz
+# ===========================================================================
+
+class TestCountImagesInCbz:
+    """Pin the image-count logic, extension coverage, and error handling."""
+
+    # --- basic counts --------------------------------------------------------
+
+    def test_three_jpg_pages_returns_3(self, cbz_factory):
+        """cbz_factory(pages=3) -> 3 .jpg members -> count returns 3."""
+        path = cbz_factory(pages=3)
+        assert kce.count_images_in_cbz(path) == 3
+
+    def test_single_default_page_returns_1(self, cbz_factory):
+        """Default cbz_factory() adds one 'page_001.jpg' -> count is 1."""
+        path = cbz_factory()
+        assert kce.count_images_in_cbz(path) == 1
+
+    def test_zero_images_xml_only_returns_0(self, cbz_factory):
+        """Archive with only a ComicInfo.xml (no image extensions) -> 0."""
+        path = cbz_factory(entries={"ComicInfo.xml": b"<ComicInfo/>"})
+        assert kce.count_images_in_cbz(path) == 0
+
+    def test_return_type_is_int(self, cbz_factory):
+        """The return value is always int, not None or bool."""
+        path = cbz_factory(pages=2)
+        result = kce.count_images_in_cbz(path)
+        assert isinstance(result, int)
+
+    # --- extension coverage --------------------------------------------------
+
+    def test_jpg_jpeg_png_tbn_webp_all_counted(self, cbz_factory, jpeg_bytes):
+        """All five image_extensions are counted: .jpg .jpeg .png .tbn .webp."""
+        jbytes = jpeg_bytes()
+        path = cbz_factory(
+            entries={
+                "page_001.jpg": jbytes,
+                "page_002.jpeg": jbytes,
+                "page_003.png": jbytes,
+                "thumbnail.tbn": jbytes,
+                "page_004.webp": jbytes,
+                # Non-image entries that must NOT be counted
+                "ComicInfo.xml": b"<x/>",
+                "thumbs.db": b"not-an-image",
+            }
+        )
+        assert kce.count_images_in_cbz(path) == 5
+
+    def test_non_image_extension_not_counted(self, cbz_factory):
+        """Files with non-image extensions (.xml, .db, .txt) are excluded."""
+        path = cbz_factory(
+            entries={
+                "ComicInfo.xml": b"<x/>",
+                "thumbs.db": b"data",
+                "notes.txt": b"text",
+            }
+        )
+        assert kce.count_images_in_cbz(path) == 0
+
+    def test_tbn_extension_counted(self, cbz_factory, jpeg_bytes):
+        """'.tbn' files are included in image_extensions and therefore counted."""
+        path = cbz_factory(
+            entries={
+                "thumbnail.tbn": jpeg_bytes(),
+                "page_001.jpg": jpeg_bytes(),
+            }
+        )
+        assert kce.count_images_in_cbz(path) == 2
+
+    def test_extension_check_is_case_insensitive_via_lower(self, cbz_factory, jpeg_bytes):
+        """namelist entries are lowercased before endswith check — .JPG is counted.
+
+        FLAG: the production code does f.lower().endswith(tuple(image_extensions)),
+        so '.JPG' is treated the same as '.jpg'.
+        """
+        path = cbz_factory(
+            entries={"PAGE_001.JPG": jpeg_bytes()}
+        )
+        # .JPG lowercased to .jpg which is in image_extensions
+        assert kce.count_images_in_cbz(path) == 1
+
+    # --- subfolder pages are counted -----------------------------------------
+
+    def test_pages_in_subdirectories_are_counted(self, cbz_factory, jpeg_bytes):
+        """Image files nested in subdirectories are also included in the count."""
+        jbytes = jpeg_bytes()
+        path = cbz_factory(
+            entries={
+                "vol01/page_001.jpg": jbytes,
+                "vol01/page_002.jpg": jbytes,
+                "ComicInfo.xml": b"<x/>",
+            }
+        )
+        assert kce.count_images_in_cbz(path) == 2
+
+    # --- error handling: bad zip / missing file ------------------------------
+
+    def test_bad_zip_returns_0(self, tmp_path):
+        """BadZipFile is caught; 0 is returned.
+
+        FLAG: the function swallows BadZipFile and returns the integer 0 (not None).
+        """
+        bad = _make_bad_zip(tmp_path, "corrupted.cbz")
+        result = kce.count_images_in_cbz(str(bad))
+        assert result == 0
+        assert isinstance(result, int)
+
+    def test_missing_file_raises_file_not_found(self, tmp_path):
+        """FileNotFoundError is NOT caught — it propagates to the caller.
+
+        FLAG: unlike get_file_from_zip, count_images_in_cbz does not swallow
+        FileNotFoundError; it propagates from zipfile.ZipFile.__init__.
+        """
+        with pytest.raises(FileNotFoundError):
+            kce.count_images_in_cbz(str(tmp_path / "no_such_file.cbz"))
+
+    # --- path forms ----------------------------------------------------------
+
+    def test_accepts_path_object(self, cbz_factory):
+        """A pathlib.Path is accepted (zipfile.ZipFile accepts os.PathLike)."""
+        path = cbz_factory(pages=2)
+        # Pass a Path, not str
+        result = kce.count_images_in_cbz(path)
+        assert result == 2
+
+    def test_accepts_str_path(self, cbz_factory):
+        """A plain str path is accepted."""
+        path = cbz_factory(pages=1)
+        result = kce.count_images_in_cbz(str(path))
+        assert result == 1

--- a/tests/archive/test_file_hash.py
+++ b/tests/archive/test_file_hash.py
@@ -1,0 +1,197 @@
+"""Characterization tests for ``kce.get_file_hash``.
+
+Signature (verified via Serena, line 2488 of komga_cover_extractor.py):
+    get_file_hash(file, is_internal=False, internal_file_name=None) -> str | None
+
+Implementation notes (pinned as-is):
+  * Uses xxhash.xxh64 internally, streaming in 64 KB chunks.
+  * Returns the hexdigest as a plain ``str`` (e.g. ``'45ab6734b21e6968'``).
+  * For ``is_internal=True`` opens the path as a ZipFile and hashes the named
+    member — the internal-member hash matches hashing those raw bytes directly.
+  * Catches ``FileNotFoundError``, ``KeyError`` (member not in zip), and all
+    other exceptions; in each case calls ``send_message(... error=True)`` and
+    returns ``None``.  No exception is propagated to the caller.
+
+All expected hash strings were obtained by running the function against
+synthesized in-memory archives / tempfiles in the project's .venv, so they
+reflect the actual xxhash library version installed.
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Known-content hash values (pinned from live runs — do NOT infer from memory)
+# ---------------------------------------------------------------------------
+
+#: xxh64 hexdigest for b'hello world'  (verified: '45ab6734b21e6968')
+HELLO_WORLD_HASH = "45ab6734b21e6968"
+
+#: xxh64 hexdigest for b'different content'  (verified: 'ea0c19ae9fbd93b3')
+DIFFERENT_CONTENT_HASH = "ea0c19ae9fbd93b3"
+
+#: xxh64 hexdigest for an empty byte stream  (verified: 'ef46db3751d8e999')
+EMPTY_FILE_HASH = "ef46db3751d8e999"
+
+
+# ---------------------------------------------------------------------------
+# Return type contract
+# ---------------------------------------------------------------------------
+
+class TestReturnType:
+    """get_file_hash always returns a plain str (never bytes, int, etc.)."""
+
+    def test_returns_str_not_bytes(self, tmp_path):
+        """The hexdigest must be a ``str``, not ``bytes``."""
+        p = tmp_path / "data.bin"
+        p.write_bytes(b"hello world")
+        result = kce.get_file_hash(p)
+        assert isinstance(result, str)
+
+    def test_known_hello_world_hash(self, tmp_path):
+        """Exact xxh64 hexdigest for b'hello world' is pinned."""
+        p = tmp_path / "hw.bin"
+        p.write_bytes(b"hello world")
+        result = kce.get_file_hash(p)
+        assert result == HELLO_WORLD_HASH
+
+    def test_empty_file_hash(self, tmp_path):
+        """Empty file returns the zero-input xxh64 digest (not None, not '')."""
+        p = tmp_path / "empty.bin"
+        p.write_bytes(b"")
+        result = kce.get_file_hash(p)
+        assert result == EMPTY_FILE_HASH
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+class TestDeterminism:
+    """Same bytes always yield the same hash; different bytes yield different."""
+
+    def test_same_content_same_hash(self, tmp_path):
+        """Two files with identical content produce identical hashes."""
+        p1 = tmp_path / "a.bin"
+        p2 = tmp_path / "b.bin"
+        p1.write_bytes(b"hello world")
+        p2.write_bytes(b"hello world")
+        assert kce.get_file_hash(p1) == kce.get_file_hash(p2)
+
+    def test_different_content_different_hash(self, tmp_path):
+        """Two files with different content produce different hashes."""
+        p1 = tmp_path / "a.bin"
+        p2 = tmp_path / "b.bin"
+        p1.write_bytes(b"hello world")
+        p2.write_bytes(b"different content")
+        h1 = kce.get_file_hash(p1)
+        h2 = kce.get_file_hash(p2)
+        assert h1 != h2
+        assert h1 == HELLO_WORLD_HASH
+        assert h2 == DIFFERENT_CONTENT_HASH
+
+    def test_repeated_calls_same_result(self, tmp_path):
+        """Calling get_file_hash twice on the same path returns the same value."""
+        p = tmp_path / "data.bin"
+        p.write_bytes(b"hello world")
+        assert kce.get_file_hash(p) == kce.get_file_hash(p)
+
+
+# ---------------------------------------------------------------------------
+# Internal zip-member hashing
+# ---------------------------------------------------------------------------
+
+class TestInternalZipMember:
+    """is_internal=True opens the file as a ZipFile and hashes the named member."""
+
+    def test_internal_member_hash_matches_raw_bytes(self, cbz_factory):
+        """Internal-member hash equals hashing those raw bytes stand-alone."""
+        inner = b"hello world"
+        cbz = cbz_factory(name="test.cbz", entries={"page_001.jpg": inner})
+        result = kce.get_file_hash(cbz, is_internal=True, internal_file_name="page_001.jpg")
+        # Internal hash should equal the xxh64 of the raw member bytes
+        assert result == HELLO_WORLD_HASH
+        assert isinstance(result, str)
+
+    def test_internal_hash_differs_from_outer_file_hash(self, cbz_factory):
+        """Outer-zip hash and inner-member hash are NOT equal (zip metadata differs)."""
+        inner = b"hello world"
+        cbz = cbz_factory(name="test.cbz", entries={"page_001.jpg": inner})
+        outer_hash = kce.get_file_hash(cbz)
+        inner_hash = kce.get_file_hash(cbz, is_internal=True, internal_file_name="page_001.jpg")
+        assert outer_hash is not None
+        assert inner_hash is not None
+        # FLAG: outer hash includes zip metadata, so it differs from member hash
+        assert outer_hash != inner_hash
+
+    def test_internal_member_is_str(self, cbz_factory):
+        """Return type for an internal member hash is str."""
+        cbz = cbz_factory(name="test.cbz", entries={"page_001.jpg": b"hello world"})
+        result = kce.get_file_hash(cbz, is_internal=True, internal_file_name="page_001.jpg")
+        assert isinstance(result, str)
+
+    def test_two_internal_members_same_content_same_hash(self, tmp_path):
+        """Two zip members with identical bytes yield the same hash."""
+        cbz = tmp_path / "dual.cbz"
+        content = b"hello world"
+        with zipfile.ZipFile(cbz, "w") as zf:
+            zf.writestr("page_001.jpg", content)
+            zf.writestr("page_002.jpg", content)
+        h1 = kce.get_file_hash(cbz, is_internal=True, internal_file_name="page_001.jpg")
+        h2 = kce.get_file_hash(cbz, is_internal=True, internal_file_name="page_002.jpg")
+        assert h1 == h2 == HELLO_WORLD_HASH
+
+    def test_two_internal_members_different_content_different_hash(self, tmp_path):
+        """Two zip members with different bytes yield different hashes."""
+        cbz = tmp_path / "dual.cbz"
+        with zipfile.ZipFile(cbz, "w") as zf:
+            zf.writestr("page_001.jpg", b"hello world")
+            zf.writestr("page_002.jpg", b"different content")
+        h1 = kce.get_file_hash(cbz, is_internal=True, internal_file_name="page_001.jpg")
+        h2 = kce.get_file_hash(cbz, is_internal=True, internal_file_name="page_002.jpg")
+        assert h1 == HELLO_WORLD_HASH
+        assert h2 == DIFFERENT_CONTENT_HASH
+        assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# Error / sentinel paths — all return None, never raise
+# ---------------------------------------------------------------------------
+
+class TestSentinelOnError:
+    """All error paths return None without propagating any exception."""
+
+    def test_missing_file_returns_none(self, tmp_path):
+        """A path that does not exist returns None (FileNotFoundError swallowed)."""
+        missing = tmp_path / "does_not_exist.bin"
+        result = kce.get_file_hash(missing)
+        # FLAG: errors are swallowed; None is the sentinel for all failure modes
+        assert result is None
+
+    def test_missing_file_does_not_raise(self, tmp_path):
+        """FileNotFoundError must not propagate to the caller."""
+        missing = tmp_path / "ghost.bin"
+        # Should not raise — characterization confirms the try/except swallows it
+        kce.get_file_hash(missing)  # no pytest.raises needed — must NOT raise
+
+    def test_nonexistent_internal_member_returns_none(self, cbz_factory):
+        """Asking for a member not in the zip returns None (KeyError swallowed)."""
+        cbz = cbz_factory(name="test.cbz", entries={"page_001.jpg": b"hello world"})
+        result = kce.get_file_hash(
+            cbz, is_internal=True, internal_file_name="nonexistent_member.jpg"
+        )
+        # FLAG: KeyError for missing zip member is swallowed and returns None
+        assert result is None
+
+    def test_nonexistent_internal_member_does_not_raise(self, cbz_factory):
+        """KeyError for a missing zip member must not propagate to caller."""
+        cbz = cbz_factory(name="test.cbz", entries={"page_001.jpg": b"data"})
+        # Must not raise
+        kce.get_file_hash(cbz, is_internal=True, internal_file_name="no_such.jpg")

--- a/tests/archive/test_header_extension.py
+++ b/tests/archive/test_header_extension.py
@@ -1,0 +1,265 @@
+"""Characterization tests for get_header_extension (magic-byte / filetype detection).
+
+Function signature (from komga_cover_extractor.py, lines 2214-2231):
+
+    def get_header_extension(file):
+        extension_from_name = get_file_extension(file)
+        if extension_from_name in manga_extensions or extension_from_name in rar_extensions:
+            try:
+                kind = filetype.guess(file)
+                if kind is None:
+                    return None
+                elif f".{kind.extension}" in manga_extensions:
+                    return ".cbz"
+                elif f".{kind.extension}" in rar_extensions:
+                    return ".cbr"
+                else:
+                    return f".{kind.extension}"
+            except Exception as e:
+                send_message(str(e), error=True)
+                return None
+        else:
+            return None
+
+Key observations from live runs (characterization, not spec):
+- manga_extensions = ['.zip', '.cbz']  (epub is excluded)
+- rar_extensions   = ['.rar', '.cbr']
+- The function short-circuits to None for ANY extension not in those two sets
+  (e.g. .txt, .epub, .7z, no-extension).
+- When magic matches a zip-family type, it returns '.cbz' (not '.zip').
+- When magic matches a rar-family type, it returns '.cbr' (not '.rar').
+- When filetype.guess returns None (unrecognised), the function returns None.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import tempfile
+import zipfile
+import os
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_tmp(tmp_path, suffix: str, data: bytes) -> str:
+    """Write *data* to a temp file with the given suffix, return its str path."""
+    p = tmp_path / f"testfile{suffix}"
+    p.write_bytes(data)
+    return str(p)
+
+
+def _real_jpeg_bytes() -> bytes:
+    """A minimal, genuinely-decodable JPEG image (filetype.guess → 'jpg')."""
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.new("RGB", (4, 4), (220, 50, 50)).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _real_zip_bytes() -> bytes:
+    """A real ZIP archive so filetype.guess → 'zip'."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("page_001.jpg", _real_jpeg_bytes())
+    return buf.getvalue()
+
+
+_RAR4_MAGIC = bytes([0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00]) + b"\x00" * 100
+"""Minimal RAR4 header bytes; enough for filetype.guess to recognise RAR."""
+
+
+# ---------------------------------------------------------------------------
+# Core cases: magic wins over file-name extension
+# ---------------------------------------------------------------------------
+
+class TestJpegBytesInCbz:
+    """JPEG magic bytes inside a .cbz file -> magic wins, returns '.jpg'."""
+
+    def test_returns_jpg_string(self, tmp_path):
+        path = _write_tmp(tmp_path, ".cbz", _real_jpeg_bytes())
+        result = kce.get_header_extension(path)
+        assert result == ".jpg"
+
+    def test_returns_str_not_bytes(self, tmp_path):
+        path = _write_tmp(tmp_path, ".cbz", _real_jpeg_bytes())
+        result = kce.get_header_extension(path)
+        assert isinstance(result, str)
+
+
+class TestRealZipInCbz:
+    """Real ZIP bytes in a .cbz file -> magic reports 'zip', mapped to '.cbz'."""
+
+    def test_returns_cbz_string(self, tmp_path):
+        path = _write_tmp(tmp_path, ".cbz", _real_zip_bytes())
+        result = kce.get_header_extension(path)
+        # ZIP magic -> ".zip" in manga_extensions -> returns ".cbz" (not ".zip")
+        assert result == ".cbz"
+
+    def test_returns_str_not_bytes(self, tmp_path):
+        path = _write_tmp(tmp_path, ".cbz", _real_zip_bytes())
+        result = kce.get_header_extension(path)
+        assert isinstance(result, str)
+
+
+class TestRealZipInZip:
+    """Real ZIP bytes in a .zip file -> same mapping, still '.cbz'."""
+
+    def test_returns_cbz_string(self, tmp_path):
+        path = _write_tmp(tmp_path, ".zip", _real_zip_bytes())
+        result = kce.get_header_extension(path)
+        assert result == ".cbz"
+
+
+class TestCbzFactoryFile:
+    """cbz_factory produces a real ZIP; ensure extension detection agrees."""
+
+    def test_cbz_factory_returns_cbz(self, cbz_factory):
+        path = cbz_factory(name="Series v01.cbz")
+        result = kce.get_header_extension(str(path))
+        assert result == ".cbz"
+
+
+# ---------------------------------------------------------------------------
+# RAR magic-byte detection
+# ---------------------------------------------------------------------------
+
+class TestRarMagicInCbr:
+    """RAR4 magic bytes in a .cbr file -> returns '.cbr'."""
+
+    def test_returns_cbr_string(self, tmp_path):
+        path = _write_tmp(tmp_path, ".cbr", _RAR4_MAGIC)
+        result = kce.get_header_extension(path)
+        assert result == ".cbr"
+
+    def test_returns_str_type(self, tmp_path):
+        path = _write_tmp(tmp_path, ".cbr", _RAR4_MAGIC)
+        result = kce.get_header_extension(path)
+        assert isinstance(result, str)
+
+
+class TestRarMagicInRar:
+    """RAR4 magic bytes in a .rar file -> returns '.cbr' (rar magic -> rar_extensions)."""
+
+    def test_returns_cbr_string(self, tmp_path):
+        path = _write_tmp(tmp_path, ".rar", _RAR4_MAGIC)
+        result = kce.get_header_extension(path)
+        assert result == ".cbr"
+
+
+class TestRarMagicInCbz:
+    """RAR4 magic bytes mis-named as .cbz -> magic wins, returns '.cbr'.
+
+    FLAG: surprising cross-family coercion — a .cbz file that is actually a
+    RAR archive is returned as '.cbr', not '.cbz'. This is intentional by
+    design (magic beats the file name) but may surprise callers.
+    """
+
+    def test_rar_bytes_in_cbz_returns_cbr(self, tmp_path):
+        path = _write_tmp(tmp_path, ".cbz", _RAR4_MAGIC)
+        result = kce.get_header_extension(path)
+        assert result == ".cbr"  # FLAG: magic always wins over the file name
+
+
+class TestZipBytesInCbr:
+    """Real ZIP bytes mis-named as .cbr -> magic reports 'zip', mapped to '.cbz'."""
+
+    def test_zip_in_cbr_returns_cbz(self, tmp_path):
+        path = _write_tmp(tmp_path, ".cbr", _real_zip_bytes())
+        result = kce.get_header_extension(path)
+        assert result == ".cbz"
+
+
+class TestJpegBytesInRar:
+    """JPEG magic bytes in a .rar file -> magic wins, returns '.jpg'."""
+
+    def test_jpeg_in_rar_returns_jpg(self, tmp_path):
+        path = _write_tmp(tmp_path, ".rar", _real_jpeg_bytes())
+        result = kce.get_header_extension(path)
+        assert result == ".jpg"
+
+
+# ---------------------------------------------------------------------------
+# Extension gating: function returns None for extensions not in manga/rar sets
+# ---------------------------------------------------------------------------
+
+class TestTextFileExtensions:
+    """Files whose extension is not in manga_extensions or rar_extensions -> None."""
+
+    def test_txt_extension_returns_none(self, tmp_path):
+        # .txt is not in manga_extensions or rar_extensions; short-circuits immediately
+        path = _write_tmp(tmp_path, ".txt", b"hello world plain text")
+        result = kce.get_header_extension(path)
+        assert result is None  # FLAG: None (not '' or False) for unknown extensions
+
+    def test_epub_extension_returns_none(self, tmp_path):
+        # .epub is in zip_extensions but NOT manga_extensions (excluded), so None
+        path = _write_tmp(tmp_path, ".epub", _real_zip_bytes())
+        result = kce.get_header_extension(path)
+        assert result is None  # FLAG: .epub short-circuits even though it is a zip
+
+    def test_seven_zip_extension_returns_none(self, tmp_path):
+        # .7z is in convertable_file_extensions but not manga_extensions or rar_extensions
+        sevenzip_magic = bytes([0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C]) + b"\x00" * 50
+        path = _write_tmp(tmp_path, ".7z", sevenzip_magic)
+        result = kce.get_header_extension(path)
+        assert result is None
+
+    def test_no_extension_returns_none(self, tmp_path):
+        # A file with no extension -> get_file_extension returns '' -> not in either set
+        path = tmp_path / "noextensionfile"
+        path.write_bytes(b"data")
+        result = kce.get_header_extension(str(path))
+        assert result is None
+
+
+class TestUnrecognisedMagicInCbz:
+    """Unrecognised magic (plain text) inside .cbz -> filetype.guess returns None -> returns None."""
+
+    def test_unrecognised_bytes_in_cbz_returns_none(self, tmp_path):
+        path = _write_tmp(tmp_path, ".cbz", b"hello world plain text not an archive")
+        result = kce.get_header_extension(path)
+        assert result is None  # FLAG: None sentinel when filetype.guess cannot identify
+
+    def test_unrecognised_bytes_in_cbr_returns_none(self, tmp_path):
+        path = _write_tmp(tmp_path, ".cbr", b"hello world plain text not an archive")
+        result = kce.get_header_extension(path)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Return type assertions across the board
+# ---------------------------------------------------------------------------
+
+class TestReturnTypes:
+    """Ensure the function never returns unexpected types."""
+
+    @pytest.mark.parametrize("suffix,data,expected", [
+        (".cbz", None, ".jpg"),   # jpeg data, recognized image
+        (".cbz", "zip", ".cbz"),  # real zip, recognized
+        (".cbr", "rar", ".cbr"),  # rar magic, recognized
+        (".txt", None, None),     # unknown extension, short-circuit
+    ])
+    def test_return_type(self, tmp_path, suffix, data, expected):
+        if data is None:
+            raw = _real_jpeg_bytes()
+        elif data == "zip":
+            raw = _real_zip_bytes()
+        elif data == "rar":
+            raw = _RAR4_MAGIC
+        else:
+            raw = data.encode()
+
+        path = _write_tmp(tmp_path, suffix, raw)
+        result = kce.get_header_extension(path)
+        assert result == expected
+        if expected is not None:
+            assert isinstance(result, str)
+        else:
+            assert result is None

--- a/tests/archive/test_internal_metadata.py
+++ b/tests/archive/test_internal_metadata.py
@@ -1,0 +1,505 @@
+"""Characterization tests for get_internal_metadata, get_novel_cover, and
+get_novel_cover_path.
+
+Design notes
+------------
+* All return values are pinned from *actual* function invocations observed via
+  the .venv interpreter against real synthesized archives.
+* Where current behaviour is surprising, a ``# FLAG:`` comment is attached.
+* ``isolated_globals`` (autouse) clears every lru_cache before/after each test.
+
+Function signatures (from source):
+  get_internal_metadata(file_path, extension) -> dict | None
+  get_novel_cover(novel_path) -> str | None
+  get_novel_cover_path(file) -> str   (takes a kce.File object)
+  parse_html_tags(html) -> dict       (BeautifulSoup-backed; tested as a helper)
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+import zipfile
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# EPUB builder helpers (stdlib zipfile; no fixtures needed for this layer)
+# ---------------------------------------------------------------------------
+
+_CONTAINER_XML_OEBPS = """\
+<?xml version="1.0" encoding="utf-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"""
+
+_CONTAINER_XML_ROOT = """\
+<?xml version="1.0" encoding="utf-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"""
+
+_CONTAINER_XML_EMPTY_ROOTFILES = """\
+<?xml version="1.0" encoding="utf-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+  </rootfiles>
+</container>"""
+
+
+def _make_epub(
+    tmp_path,
+    name: str = "test.epub",
+    container_xml: str = _CONTAINER_XML_OEBPS,
+    content_opf: str = "",
+    opf_path: str = "OEBPS/content.opf",
+    extra_entries: dict | None = None,
+) -> str:
+    """Build a minimal EPUB in tmp_path; return the file path as str."""
+    epub_path = str(tmp_path / name)
+    with zipfile.ZipFile(epub_path, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        zf.writestr("META-INF/container.xml", container_xml)
+        if content_opf:
+            zf.writestr(opf_path, content_opf)
+        if extra_entries:
+            for arcname, data in extra_entries.items():
+                zf.writestr(arcname, data)
+    return epub_path
+
+
+def _make_file_obj(path: str, extension: str = ".epub") -> kce.File:
+    """Create a minimal kce.File pointing at *path*."""
+    root = os.path.dirname(path)
+    name = os.path.basename(path)
+    extensionless_name = os.path.splitext(name)[0]
+    return kce.File(
+        name=name,
+        extensionless_name=extensionless_name,
+        basename=root,
+        extension=extension,
+        root=root,
+        path=path,
+        extensionless_path=os.path.join(root, extensionless_name),
+        volume_number=[],
+        file_type="novel" if extension == ".epub" else "manga",
+        header_extension=extension,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Minimal EPUB OPF templates
+# ---------------------------------------------------------------------------
+
+def _opf_with_cover(cover_id: str = "cover-image", cover_href: str = "images/cover.jpg") -> str:
+    return f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="BookId">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>My Novel Title</dc:title>
+    <dc:creator>Some Author</dc:creator>
+    <meta name="cover" content="{cover_id}"/>
+  </metadata>
+  <manifest>
+    <item id="{cover_id}" href="{cover_href}" media-type="image/jpeg"/>
+  </manifest>
+  <spine/>
+</package>"""
+
+
+def _opf_without_cover() -> str:
+    return """\
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>My Novel Title</dc:title>
+    <dc:creator>Some Author</dc:creator>
+  </metadata>
+  <manifest/>
+  <spine/>
+</package>"""
+
+
+def _opf_html_cover() -> str:
+    """OPF where the cover manifest item is an HTML file, not an image."""
+    return """\
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>HTML Cover Novel</dc:title>
+    <meta name="cover" content="cover-page"/>
+  </metadata>
+  <manifest>
+    <item id="cover-page" href="cover.html" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine/>
+</package>"""
+
+
+# ---------------------------------------------------------------------------
+# TestGetInternalMetadata — CBZ branch
+# ---------------------------------------------------------------------------
+
+class TestGetInternalMetadataCbz:
+    """Pin get_internal_metadata behaviour for manga (.cbz / .zip) archives."""
+
+    def test_cbz_with_comicinfo_returns_dict(self, cbz_factory, comicinfo_xml):
+        """A cbz with ComicInfo.xml returns a dict (not None)."""
+        path = cbz_factory(comicinfo_xml=comicinfo_xml(Title="T", Volume="3"))
+        result = kce.get_internal_metadata(str(path), ".cbz")
+        assert isinstance(result, dict)
+
+    def test_cbz_comicinfo_title_and_volume(self, cbz_factory, comicinfo_xml):
+        """ComicInfo Title and Volume values are returned as strings."""
+        path = cbz_factory(comicinfo_xml=comicinfo_xml(Title="My Title", Volume="3"))
+        result = kce.get_internal_metadata(str(path), ".cbz")
+        assert result["Title"] == "My Title"
+        assert result["Volume"] == "3"       # string, not int
+
+    def test_cbz_comicinfo_namespace_attrs(self, cbz_factory, comicinfo_xml):
+        """xmltodict surfaces xmlns attributes as '@xmlns:...' keys."""
+        path = cbz_factory(comicinfo_xml=comicinfo_xml(Title="T"))
+        result = kce.get_internal_metadata(str(path), ".cbz")
+        assert result["@xmlns:xsi"] == "http://www.w3.org/2001/XMLSchema-instance"
+        assert result["@xmlns:xsd"] == "http://www.w3.org/2001/XMLSchema"
+
+    def test_cbz_without_comicinfo_returns_none(self, cbz_factory):
+        """A cbz with no ComicInfo.xml returns None (contains_comic_info → False)."""
+        path = cbz_factory()  # no comicinfo_xml kwarg → no ComicInfo.xml entry
+        result = kce.get_internal_metadata(str(path), ".cbz")
+        assert result is None
+
+    def test_zip_with_comicinfo_returns_dict(self, cbz_factory, comicinfo_xml):
+        """Extension .zip is also in manga_extensions; same code path executes."""
+        path = cbz_factory(name="vol.zip", comicinfo_xml=comicinfo_xml(Title="Zip", Volume="7"))
+        result = kce.get_internal_metadata(str(path), ".zip")
+        assert isinstance(result, dict)
+        assert result["Title"] == "Zip"
+        assert result["Volume"] == "7"
+
+    def test_zip_without_comicinfo_returns_none(self, cbz_factory):
+        """A .zip without ComicInfo.xml → None."""
+        path = cbz_factory(name="empty.zip")
+        result = kce.get_internal_metadata(str(path), ".zip")
+        assert result is None
+
+    def test_cbz_multiple_comicinfo_fields(self, cbz_factory, comicinfo_xml):
+        """Multiple ComicInfo fields survive the round-trip intact."""
+        path = cbz_factory(
+            comicinfo_xml=comicinfo_xml(
+                Title="My Series", Volume="3", Year="2020", Publisher="Viz"
+            )
+        )
+        result = kce.get_internal_metadata(str(path), ".cbz")
+        assert result["Title"] == "My Series"
+        assert result["Volume"] == "3"
+        assert result["Year"] == "2020"
+        assert result["Publisher"] == "Viz"
+
+    def test_cbz_corrupt_file_returns_none(self, tmp_path):
+        """A file that is not a valid zip → None (exception swallowed).
+
+        FLAG: BadZipFile raised inside get_file_from_zip is caught; the outer
+        try/except in get_internal_metadata also catches any propagated errors
+        and returns None.
+        """
+        bad = tmp_path / "corrupt.cbz"
+        bad.write_bytes(b"NOT A ZIP FILE")
+        result = kce.get_internal_metadata(str(bad), ".cbz")
+        assert result is None
+
+    def test_unknown_extension_returns_none(self, cbz_factory):
+        """An extension that is neither manga_extensions nor novel_extensions → None."""
+        path = cbz_factory()
+        result = kce.get_internal_metadata(str(path), ".unknown")
+        assert result is None
+
+    def test_cbz_return_type_is_dict(self, cbz_factory, comicinfo_xml):
+        """The returned dict is a plain dict (not an OrderedDict subclass)."""
+        path = cbz_factory(comicinfo_xml=comicinfo_xml(Title="T"))
+        result = kce.get_internal_metadata(str(path), ".cbz")
+        assert type(result) is dict
+
+
+# ---------------------------------------------------------------------------
+# TestGetInternalMetadataEpub — EPUB branch
+# ---------------------------------------------------------------------------
+
+class TestGetInternalMetadataEpub:
+    """Pin get_internal_metadata behaviour for novel (.epub) archives."""
+
+    def test_epub_with_opf_returns_dict(self, tmp_path):
+        """An EPUB with a content.opf returns a dict parsed by BeautifulSoup."""
+        epub = _make_epub(tmp_path, content_opf=_opf_with_cover())
+        warnings.filterwarnings("ignore")
+        result = kce.get_internal_metadata(epub, ".epub")
+        assert isinstance(result, dict)
+
+    def test_epub_dc_title_present(self, tmp_path):
+        """The dc:title field is extracted from the OPF metadata."""
+        epub = _make_epub(tmp_path, content_opf=_opf_with_cover())
+        warnings.filterwarnings("ignore")
+        result = kce.get_internal_metadata(epub, ".epub")
+        assert result["dc:title"] == "My Novel Title"
+
+    def test_epub_dc_creator_present(self, tmp_path):
+        """The dc:creator field is extracted from the OPF metadata."""
+        epub = _make_epub(tmp_path, content_opf=_opf_with_cover())
+        warnings.filterwarnings("ignore")
+        result = kce.get_internal_metadata(epub, ".epub")
+        assert result["dc:creator"] == "Some Author"
+
+    def test_epub_meta_tag_value_is_empty_string(self, tmp_path):
+        """The <meta name='cover' .../> element: BeautifulSoup returns '' for get_text().
+
+        FLAG: BeautifulSoup's html.parser flattens the 'name' and 'content'
+        attributes; the text content of the <meta> tag is the empty string ''.
+        """
+        epub = _make_epub(tmp_path, content_opf=_opf_with_cover())
+        warnings.filterwarnings("ignore")
+        result = kce.get_internal_metadata(epub, ".epub")
+        assert result["meta"] == ""
+
+    def test_epub_package_key_is_concatenated_text(self, tmp_path):
+        """The root <package> tag's text() is all inner text concatenated."""
+        epub = _make_epub(tmp_path, content_opf=_opf_with_cover())
+        warnings.filterwarnings("ignore")
+        result = kce.get_internal_metadata(epub, ".epub")
+        # 'package' key exists and contains the title text
+        assert "package" in result
+        assert "My Novel Title" in result["package"]
+
+    def test_epub_without_opf_returns_none(self, tmp_path):
+        """An EPUB whose container.xml points to a non-existent OPF → None.
+
+        FLAG: get_file_from_zip finds nothing → opf is None → metadata stays
+        None, and send_message logs 'No opf file found'.
+        """
+        # container.xml points to OEBPS/content.opf, but we don't write that file.
+        epub = _make_epub(tmp_path, name="noopf.epub", content_opf="")
+        result = kce.get_internal_metadata(epub, ".epub")
+        assert result is None
+
+    def test_epub_return_type_is_dict_when_found(self, tmp_path):
+        """get_internal_metadata returns a plain dict for a well-formed EPUB."""
+        epub = _make_epub(tmp_path, content_opf=_opf_with_cover())
+        warnings.filterwarnings("ignore")
+        result = kce.get_internal_metadata(epub, ".epub")
+        assert type(result) is dict
+
+    def test_epub_item_tag_value_is_empty_string(self, tmp_path):
+        """Void <item ...> tags: BeautifulSoup get_text() returns '' for each.
+
+        FLAG: The html.parser does not preserve self-closing attribute values;
+        both 'item' and 'itemref' keys map to '' (last seen tag wins).
+        """
+        epub = _make_epub(tmp_path, content_opf=_opf_with_cover())
+        warnings.filterwarnings("ignore")
+        result = kce.get_internal_metadata(epub, ".epub")
+        assert result["item"] == ""
+
+
+# ---------------------------------------------------------------------------
+# TestGetNovelCover — direct function tests
+# ---------------------------------------------------------------------------
+
+class TestGetNovelCover:
+    """Pin get_novel_cover(novel_path) behaviour."""
+
+    def test_epub_with_cover_returns_internal_path(self, tmp_path):
+        """When the OPF has a cover meta + manifest item, the internal path is returned."""
+        epub = _make_epub(tmp_path, content_opf=_opf_with_cover(cover_href="images/cover.jpg"))
+        result = kce.get_novel_cover(epub)
+        # cover_path = os.path.join(os.path.dirname("OEBPS/content.opf"), "images/cover.jpg")
+        assert result == "OEBPS/images/cover.jpg"
+
+    def test_epub_with_root_level_opf_cover(self, tmp_path):
+        """When the OPF is at the zip root (no parent dir), the cover path is direct."""
+        epub = _make_epub(
+            tmp_path,
+            name="root.epub",
+            container_xml=_CONTAINER_XML_ROOT,
+            content_opf=_opf_with_cover(cover_href="cover.jpg"),
+            opf_path="content.opf",
+        )
+        result = kce.get_novel_cover(epub)
+        assert result == "cover.jpg"
+
+    def test_epub_without_cover_meta_returns_none(self, tmp_path):
+        """When OPF has no <meta name='cover'> element, None is returned."""
+        epub = _make_epub(tmp_path, name="nocover.epub", content_opf=_opf_without_cover())
+        result = kce.get_novel_cover(epub)
+        assert result is None
+
+    def test_epub_no_rootfiles_returns_none(self, tmp_path):
+        """When container.xml has empty <rootfiles>, None is returned."""
+        epub = _make_epub(
+            tmp_path,
+            name="norootfile.epub",
+            container_xml=_CONTAINER_XML_EMPTY_ROOTFILES,
+            content_opf="",
+        )
+        result = kce.get_novel_cover(epub)
+        assert result is None
+
+    def test_epub_url_encoded_cover_href_is_decoded(self, tmp_path):
+        """URL-encoded spaces in href (e.g. 'cover%20image.jpg') are decoded.
+
+        FLAG: The code calls urllib.parse.unquote() when '%' appears in the href,
+        so the returned path has literal spaces, not percent-encoding.
+        """
+        encoded_opf = _opf_with_cover(cover_href="images/cover%20image.jpg")
+        epub = _make_epub(tmp_path, name="encoded.epub", content_opf=encoded_opf)
+        result = kce.get_novel_cover(epub)
+        assert result == "OEBPS/images/cover image.jpg"
+
+    def test_epub_html_cover_returns_html_path(self, tmp_path):
+        """When the cover manifest item is an HTML file, its path is still returned."""
+        epub = _make_epub(tmp_path, name="htmlcover.epub", content_opf=_opf_html_cover())
+        result = kce.get_novel_cover(epub)
+        assert result == "OEBPS/cover.html"
+
+    def test_nonexistent_path_returns_none(self):
+        """A path that doesn't exist on disk → None (exception swallowed)."""
+        result = kce.get_novel_cover("/nonexistent/path.epub")
+        assert result is None
+
+    def test_return_type_is_str_when_found(self, tmp_path):
+        """The returned cover path is a plain str."""
+        epub = _make_epub(tmp_path, content_opf=_opf_with_cover())
+        result = kce.get_novel_cover(epub)
+        assert isinstance(result, str)
+
+    def test_return_type_is_none_when_not_found(self, tmp_path):
+        """When no cover is found, the return value is exactly None."""
+        epub = _make_epub(tmp_path, name="nocov2.epub", content_opf=_opf_without_cover())
+        result = kce.get_novel_cover(epub)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestGetNovelCoverPath — File-object-level function
+# ---------------------------------------------------------------------------
+
+class TestGetNovelCoverPath:
+    """Pin get_novel_cover_path(file) behaviour."""
+
+    def test_epub_with_image_cover_returns_basename(self, tmp_path):
+        """When the EPUB has an image cover, the basename of the cover is returned."""
+        epub = _make_epub(tmp_path, content_opf=_opf_with_cover(cover_href="images/cover.jpg"))
+        f = _make_file_obj(epub, ".epub")
+        result = kce.get_novel_cover_path(f)
+        # os.path.basename("OEBPS/images/cover.jpg") == "cover.jpg"
+        assert result == "cover.jpg"
+
+    def test_non_epub_extension_returns_empty_string(self, tmp_path):
+        """Files with .cbz extension (not in novel_extensions) → '' immediately."""
+        cbz = tmp_path / "test.cbz"
+        with zipfile.ZipFile(str(cbz), "w") as zf:
+            zf.writestr("page.jpg", b"fake")
+        f = _make_file_obj(str(cbz), ".cbz")
+        result = kce.get_novel_cover_path(f)
+        assert result == ""
+
+    def test_epub_without_cover_returns_empty_string(self, tmp_path):
+        """EPUB with no cover meta tag → get_novel_cover returns None → '' returned."""
+        epub = _make_epub(tmp_path, name="nocover2.epub", content_opf=_opf_without_cover())
+        f = _make_file_obj(epub, ".epub")
+        result = kce.get_novel_cover_path(f)
+        assert result == ""
+
+    def test_epub_html_cover_returns_empty_string(self, tmp_path):
+        """When cover href points to an HTML file (not an image), '' is returned.
+
+        FLAG: get_novel_cover returns the path but get_novel_cover_path checks
+        whether the extension is in image_extensions; HTML is not, so '' is returned.
+        """
+        epub = _make_epub(tmp_path, name="htmlcov2.epub", content_opf=_opf_html_cover())
+        f = _make_file_obj(epub, ".epub")
+        result = kce.get_novel_cover_path(f)
+        assert result == ""
+
+    def test_epub_url_encoded_image_cover_returns_basename(self, tmp_path):
+        """URL-encoded cover href: after decoding it should be a .jpg → basename returned."""
+        encoded_opf = _opf_with_cover(cover_href="images/cover%20main.jpg")
+        epub = _make_epub(tmp_path, name="urlenc2.epub", content_opf=encoded_opf)
+        f = _make_file_obj(epub, ".epub")
+        result = kce.get_novel_cover_path(f)
+        assert result == "cover main.jpg"
+
+    def test_return_type_is_str(self, tmp_path):
+        """get_novel_cover_path always returns str (never None)."""
+        epub = _make_epub(tmp_path, name="rettype.epub", content_opf=_opf_with_cover())
+        f = _make_file_obj(epub, ".epub")
+        result = kce.get_novel_cover_path(f)
+        assert type(result) is str
+
+    def test_return_empty_str_on_no_cover(self, tmp_path):
+        """get_novel_cover_path returns '' (empty str), never None, on failure."""
+        epub = _make_epub(tmp_path, name="empty2.epub", content_opf=_opf_without_cover())
+        f = _make_file_obj(epub, ".epub")
+        result = kce.get_novel_cover_path(f)
+        assert result == ""
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# TestParseHtmlTags — direct BS4 helper
+# ---------------------------------------------------------------------------
+
+class TestParseHtmlTags:
+    """Pin parse_html_tags behaviour (BeautifulSoup html.parser backend)."""
+
+    def test_basic_xml_tag_extraction(self):
+        """Each tag name becomes a key; get_text() is the value."""
+        html = b"<root><title>Hello</title></root>"
+        warnings.filterwarnings("ignore")
+        result = kce.parse_html_tags(html)
+        assert isinstance(result, dict)
+        assert result["title"] == "Hello"
+
+    def test_meta_self_closing_tag_has_empty_value(self):
+        """Self-closing tags like <meta .../> have empty string text content."""
+        html = b'<root><meta name="cover" content="img"/></root>'
+        warnings.filterwarnings("ignore")
+        result = kce.parse_html_tags(html)
+        assert result["meta"] == ""
+
+    def test_opf_dc_title_extracted(self):
+        """dc:title tags (which use colons) are extracted with their qualified name."""
+        html = b"<metadata><dc:title>My Book</dc:title></metadata>"
+        warnings.filterwarnings("ignore")
+        result = kce.parse_html_tags(html)
+        assert result["dc:title"] == "My Book"
+
+    def test_returns_dict(self):
+        """Return type is plain dict."""
+        html = b"<root><a>1</a></root>"
+        warnings.filterwarnings("ignore")
+        result = kce.parse_html_tags(html)
+        assert type(result) is dict
+
+    def test_empty_bytes_returns_empty_dict(self):
+        """Empty bytes input → empty dict (no tags to find)."""
+        warnings.filterwarnings("ignore")
+        result = kce.parse_html_tags(b"")
+        assert result == {}
+
+    def test_repeated_tag_name_last_value_wins(self):
+        """When the same tag appears multiple times, the last text value is stored.
+
+        FLAG: parse_html_tags uses a dict comprehension, so repeated tag names
+        collide and the last occurrence wins.
+        """
+        html = b"<root><item>first</item><item>second</item></root>"
+        warnings.filterwarnings("ignore")
+        result = kce.parse_html_tags(html)
+        # FLAG: dict comprehension = last item's text wins
+        assert result["item"] == "second"

--- a/tests/archive/test_zip_comment.py
+++ b/tests/archive/test_zip_comment.py
@@ -1,0 +1,255 @@
+"""Characterization tests for get_zip_comment and get_zip_comment_cache.
+
+Both functions read a ZIP/CBZ file's EOCD comment via stdlib zipfile and return
+a str (decoded UTF-8). On any error — bad path, non-zip bytes, bad UTF-8 —
+they swallow the exception, print an error via send_message, and return ''.
+
+get_zip_comment_cache is the lru_cache(maxsize=None) variant; get_zip_comment
+is the uncached variant used for freshly-downloaded files.
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+
+import komga_cover_extractor as kce
+from _kce_support import clear_all_caches
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_non_zip(tmp_path, name="notazip.cbz") -> "Path":
+    """Write raw non-ZIP bytes to a file and return its path."""
+    p = tmp_path / name
+    p.write_bytes(b"this is not a zip file at all!")
+    return p
+
+
+# ===========================================================================
+# get_zip_comment  (uncached)
+# ===========================================================================
+
+class TestGetZipComment:
+    """Pin exact return types and values for the uncached get_zip_comment."""
+
+    def test_comment_decoded_as_str(self, cbz_factory):
+        """cbz_factory(comment=b'release-group-name') -> 'release-group-name' (str)."""
+        path = cbz_factory(comment=b"release-group-name")
+        result = kce.get_zip_comment(str(path))
+        assert result == "release-group-name"
+        assert isinstance(result, str)
+
+    def test_comment_returns_exact_decoded_string(self, cbz_factory):
+        """The bytes comment is decoded to str via UTF-8 — verify the exact value."""
+        path = cbz_factory(comment=b"release-group-name")
+        assert kce.get_zip_comment(str(path)) == "release-group-name"
+
+    def test_no_comment_returns_empty_string(self, cbz_factory):
+        """Archive with no comment -> '' (empty str, not None)."""
+        path = cbz_factory()  # default: no comment set
+        result = kce.get_zip_comment(str(path))
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_missing_path_returns_empty_string(self):
+        """Nonexistent path -> '' (error swallowed, sentinel returned).
+
+        FLAG: the function silently returns '' for missing files instead of raising,
+        only emitting a send_message error log.
+        """
+        result = kce.get_zip_comment("/nonexistent/path/test.cbz")
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_non_zip_file_returns_empty_string(self, tmp_path):
+        """Non-ZIP file -> '' (BadZipFile error swallowed).
+
+        FLAG: BadZipFile is caught and '' is returned; the caller never sees an exception.
+        """
+        path = _make_non_zip(tmp_path)
+        result = kce.get_zip_comment(str(path))
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_invalid_utf8_comment_returns_empty_string(self, tmp_path):
+        """Comment bytes that are not valid UTF-8 -> '' (UnicodeDecodeError swallowed).
+
+        FLAG: invalid UTF-8 in the comment is silently swallowed; '' is returned.
+        """
+        path = tmp_path / "bad_utf8.cbz"
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("page_001.jpg", b"JFIF")
+            zf.comment = b"\xff\xfe"  # invalid UTF-8 start bytes
+        result = kce.get_zip_comment(str(path))
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_unicode_comment_decoded_correctly(self, tmp_path):
+        """Unicode comment (valid UTF-8 bytes) is decoded to a proper Python str."""
+        unicode_comment = "manga-group-ユニコード"
+        path = tmp_path / "unicode.cbz"
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("page_001.jpg", b"JFIF")
+            zf.comment = unicode_comment.encode("utf-8")
+        result = kce.get_zip_comment(str(path))
+        assert result == unicode_comment
+        assert isinstance(result, str)
+
+    def test_single_char_comment(self, cbz_factory):
+        """Minimal comment: a single ASCII byte is decoded to a 1-char str."""
+        path = cbz_factory(comment=b"b")
+        result = kce.get_zip_comment(str(path))
+        assert result == "b"
+
+    def test_returns_str_not_bytes(self, cbz_factory):
+        """Return type is always str — raw bytes are never returned."""
+        path = cbz_factory(comment=b"grp")
+        result = kce.get_zip_comment(str(path))
+        assert type(result) is str  # not bytes
+
+    def test_path_object_accepted(self, cbz_factory):
+        """Passing a Path object (not str) is also accepted by zipfile.ZipFile."""
+        path = cbz_factory(comment=b"release-group-name")
+        # Path objects work because zipfile accepts os.PathLike
+        result = kce.get_zip_comment(path)
+        assert result == "release-group-name"
+
+
+# ===========================================================================
+# get_zip_comment_cache  (lru_cache(maxsize=None))
+# ===========================================================================
+
+class TestGetZipCommentCache:
+    """Pin return values AND caching behaviour for the cached variant."""
+
+    def test_comment_decoded_as_str(self, cbz_factory):
+        """Same decoding as the uncached version: returns a str."""
+        path = cbz_factory(comment=b"my-release-group")
+        result = kce.get_zip_comment_cache(str(path))
+        assert result == "my-release-group"
+        assert isinstance(result, str)
+
+    def test_no_comment_returns_empty_string(self, cbz_factory):
+        """No comment -> '' (matches uncached behaviour)."""
+        path = cbz_factory()
+        result = kce.get_zip_comment_cache(str(path))
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_missing_path_returns_empty_string(self):
+        """Nonexistent path -> '' (error swallowed, same as uncached variant).
+
+        FLAG: silent '' sentinel on missing file.
+        """
+        result = kce.get_zip_comment_cache("/nonexistent/path/test.cbz")
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_maxsize_is_none(self):
+        """Cache is unbounded: lru_cache(maxsize=None)."""
+        ci = kce.get_zip_comment_cache.cache_info()
+        assert ci.maxsize is None
+
+    def test_cache_hit_on_second_call(self, cbz_factory):
+        """Second call with the same argument returns a cache hit."""
+        path = cbz_factory(comment=b"cached-group")
+        clear_all_caches()
+
+        kce.get_zip_comment_cache(str(path))
+        kce.get_zip_comment_cache(str(path))
+
+        ci = kce.get_zip_comment_cache.cache_info()
+        assert ci.hits >= 1
+        assert ci.misses == 1
+        assert ci.currsize == 1
+
+    def test_cached_value_matches_first_result(self, cbz_factory):
+        """Cached return equals the first computed return."""
+        path = cbz_factory(comment=b"cached-group")
+        clear_all_caches()
+
+        result1 = kce.get_zip_comment_cache(str(path))
+        result2 = kce.get_zip_comment_cache(str(path))
+        assert result1 == result2 == "cached-group"
+
+    def test_cache_survives_file_deletion(self, cbz_factory):
+        """After the file is deleted the cache still returns the original value.
+
+        Demonstrates that result is memoised from first call, NOT re-read.
+        """
+        import os
+        path = cbz_factory(comment=b"cached-group")
+        clear_all_caches()
+
+        result_before = kce.get_zip_comment_cache(str(path))
+        os.remove(path)  # delete the file
+
+        result_after = kce.get_zip_comment_cache(str(path))
+        assert result_before == result_after == "cached-group"
+
+        ci = kce.get_zip_comment_cache.cache_info()
+        assert ci.hits == 1  # second call was a cache hit, not a disk read
+
+    def test_distinct_paths_are_distinct_cache_entries(self, cbz_factory, tmp_path):
+        """Two different archive paths are cached independently."""
+        path1 = cbz_factory(name="series_a.cbz", comment=b"group-a")
+        path2 = cbz_factory(name="series_b.cbz", comment=b"group-b")
+        clear_all_caches()
+
+        r1 = kce.get_zip_comment_cache(str(path1))
+        r2 = kce.get_zip_comment_cache(str(path2))
+
+        assert r1 == "group-a"
+        assert r2 == "group-b"
+        assert kce.get_zip_comment_cache.cache_info().currsize == 2
+
+    def test_cache_cleared_by_autouse_fixture(self, cbz_factory):
+        """The autouse isolated_globals fixture clears caches between tests.
+
+        If this test sees currsize > 0 before any call, the fixture did not clear.
+        """
+        ci_before = kce.get_zip_comment_cache.cache_info()
+        assert ci_before.currsize == 0
+
+        path = cbz_factory(comment=b"grp")
+        kce.get_zip_comment_cache(str(path))
+        assert kce.get_zip_comment_cache.cache_info().currsize == 1
+
+    def test_non_zip_file_returns_empty_string(self, tmp_path):
+        """Non-ZIP file -> '' (same behaviour as uncached variant).
+
+        FLAG: BadZipFile swallowed; '' cached and returned.
+        """
+        path = _make_non_zip(tmp_path, "notazip_cached.cbz")
+        result = kce.get_zip_comment_cache(str(path))
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_unicode_comment(self, tmp_path):
+        """Unicode comment round-trips correctly through the cache."""
+        unicode_comment = "group-ユニコード"
+        path = tmp_path / "unicode_cached.cbz"
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("page_001.jpg", b"JFIF")
+            zf.comment = unicode_comment.encode("utf-8")
+
+        result = kce.get_zip_comment_cache(str(path))
+        assert result == unicode_comment
+        assert isinstance(result, str)
+
+    def test_invalid_utf8_returns_empty_string(self, tmp_path):
+        """Invalid UTF-8 comment bytes -> '' (UnicodeDecodeError swallowed and cached).
+
+        FLAG: '' is cached on first call; subsequent calls return '' from cache.
+        """
+        path = tmp_path / "bad_utf8_cached.cbz"
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("page_001.jpg", b"JFIF")
+            zf.comment = b"\xff\xfe"
+        result = kce.get_zip_comment_cache(str(path))
+        assert result == ""
+        assert isinstance(result, str)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,257 @@
+"""Shared pytest fixtures for the komga_cover_extractor characterization suite.
+
+Design notes (read before adding tests):
+
+* **Characterization, not correctness.** These tests pin what the code does
+  *today* so a later modularization refactor is provably behavior-preserving.
+  When a function's current behavior is surprising or buggy, we pin it AS-IS and
+  add a ``# FLAG:`` comment — we never "fix" production behavior in a test PR.
+
+* **The module under test is imported once as ``kce``.** Because the production
+  module does ``from settings import *``, every setting is rebound as an
+  attribute on the ``komga_cover_extractor`` module namespace. So tests and
+  fixtures must patch ``kce.<setting>`` (e.g. ``kce.paths``), NOT
+  ``settings.<setting>`` — patching the settings module would not affect the
+  already-bound globals the code actually reads.
+
+* **Global isolation is autouse.** ``isolated_globals`` snapshots every simple
+  data attribute on ``kce`` (the settings toggles AND the mutable pipeline
+  state: ``processed_files``, ``grouped_notifications``, ``release_groups``,
+  ``image_count``, ``series_cover_path``, ``session_objects``, ...), restores
+  them after each test, and clears every ``lru_cache`` on the module. The
+  snapshot is built by runtime introspection so it auto-syncs as the module
+  changes (24 caches today). This lets tests freely mutate globals without
+  bleeding into one another.
+
+* **``Volume`` has no ``__eq__``.** Equality is identity. Do not write
+  ``assert vol_a == vol_b`` expecting field comparison — compare fields
+  explicitly. (``tests.py`` additionally redefines its own ``Volume`` with an
+  extra ``is_fixed`` field; this suite uses the PRODUCTION ``kce.Volume``.)
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import zipfile
+
+import pytest
+
+import komga_cover_extractor as kce
+from _kce_support import (
+    REPO_ROOT,
+    SNAPSHOT_TYPES as _SNAPSHOT_TYPES,
+    clear_all_caches,
+    real_jpeg_bytes as _real_jpeg_bytes,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_globals():
+    """Snapshot & restore all simple-data globals on ``kce``; clear lru_caches.
+
+    Autouse: every test in the suite gets a clean, restored module namespace.
+    """
+    snapshot = {}
+    for name in dir(kce):
+        if name.startswith("__"):
+            continue
+        try:
+            value = getattr(kce, name)
+        except Exception:
+            continue
+        if isinstance(value, _SNAPSHOT_TYPES):
+            try:
+                snapshot[name] = copy.deepcopy(value)
+            except Exception:
+                # Unsnapshottable simple value — skip rather than fail the test.
+                pass
+
+    clear_all_caches()
+    try:
+        yield
+    finally:
+        for name, value in snapshot.items():
+            try:
+                setattr(kce, name, value)
+            except Exception:
+                pass
+        clear_all_caches()
+
+
+# --------------------------------------------------------------------------- #
+# Archive fixtures — synthesize tiny .cbz/.zip in-memory (stdlib zipfile).
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def jpeg_bytes():
+    """Factory for small real JPEG bytes: ``jpeg_bytes(color=(r,g,b))``."""
+    return _real_jpeg_bytes
+
+
+@pytest.fixture
+def comicinfo_xml():
+    """Build a minimal ComicInfo.xml string from keyword fields.
+
+    Usage: ``comicinfo_xml(Title="T", Volume="3", Year="2020")``.
+    """
+    def _build(**fields) -> str:
+        body = "".join(f"  <{k}>{v}</{k}>\n" for k, v in fields.items())
+        return (
+            '<?xml version="1.0" encoding="utf-8"?>\n'
+            '<ComicInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+            'xmlns:xsd="http://www.w3.org/2001/XMLSchema">\n'
+            f"{body}"
+            "</ComicInfo>\n"
+        )
+
+    return _build
+
+
+@pytest.fixture
+def cbz_factory(tmp_path):
+    """Write an in-memory zip to ``tmp_path`` and return its path.
+
+    Parameters (all optional):
+      * ``name``        — archive filename (default ``"Series v01.cbz"``).
+      * ``entries``     — dict {arcname: bytes|str} of members to add. If omitted,
+                          a single real-JPEG page ``"page_001.jpg"`` is added so
+                          image-decoding paths work.
+      * ``comment``     — bytes set as the zip's EOCD comment.
+      * ``comicinfo_xml`` — str written as ``ComicInfo.xml``.
+      * ``pages``       — int; add N real-JPEG pages named ``page_NNN.jpg``.
+    """
+    def _build(
+        name: str = "Series v01.cbz",
+        entries: dict | None = None,
+        comment: bytes | None = None,
+        comicinfo_xml: str | None = None,
+        pages: int | None = None,
+    ):
+        path = tmp_path / name
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            if entries:
+                for arcname, data in entries.items():
+                    zf.writestr(
+                        arcname,
+                        data if isinstance(data, (bytes, bytearray)) else str(data),
+                    )
+            if pages:
+                for i in range(1, pages + 1):
+                    zf.writestr(f"page_{i:03d}.jpg", _real_jpeg_bytes())
+            if not entries and not pages:
+                zf.writestr("page_001.jpg", _real_jpeg_bytes())
+            if comicinfo_xml is not None:
+                zf.writestr("ComicInfo.xml", comicinfo_xml)
+            if comment is not None:
+                zf.comment = comment
+        return path
+
+    return _build
+
+
+# --------------------------------------------------------------------------- #
+# Image + filesystem fixtures.
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def tiny_image():
+    """Factory returning an in-memory PIL Image: ``tiny_image(color, size)``."""
+    from PIL import Image
+
+    def _build(color=(255, 255, 255), size=(4, 4), mode="RGB"):
+        return Image.new(mode, size, color)
+
+    return _build
+
+
+@pytest.fixture
+def tmp_library_tree(tmp_path, cbz_factory):
+    """Build ``root/<Series>/<Series> vNN.cbz`` tree with real JPEG pages.
+
+    Returns the root Path. ``series`` and ``volumes`` are tunable via the
+    returned builder is unnecessary; the default tree has one series, 2 volumes.
+    """
+    root = tmp_path / "library"
+    series_dir = root / "Test Series"
+    series_dir.mkdir(parents=True)
+    for n in (1, 2):
+        path = series_dir / f"Test Series v{n:02d}.cbz"
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("page_001.jpg", _real_jpeg_bytes())
+    return root
+
+
+@pytest.fixture
+def blank_image_paths():
+    """Absolute paths to the repo's reference blank cover images."""
+    return {
+        "white": os.path.join(REPO_ROOT, "blank_white.jpg"),
+        "black": os.path.join(REPO_ROOT, "blank_black.png"),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Network mock — for Komga / Bookwalker / Discord (PR8). See docstring caveat:
+# Session-based paths (scrape_url via get_session_object, Komga via HTTPBasicAuth)
+# patch THAT object, not kce.requests; this fixture covers the plain requests.get
+# / requests.post surface. PR8 adds the targeted Session/webhook patches.
+# --------------------------------------------------------------------------- #
+
+class _FakeResponse:
+    def __init__(self, status_code=200, json_data=None, text="", content=b""):
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else {}
+        self.text = text
+        self.content = content
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+
+            raise requests.HTTPError(f"status {self.status_code}")
+
+
+@pytest.fixture
+def fake_response():
+    """Factory for a minimal requests-like response object."""
+    return _FakeResponse
+
+
+@pytest.fixture
+def mock_requests(monkeypatch):
+    """Patch ``kce.requests.get``/``post`` to return queued fake responses.
+
+    Returns a small controller: ``mock_requests.get_returns(resp)`` /
+    ``.post_returns(resp)``. NOTE (critic §3.7): this does not cover Session-based
+    paths; PR8 patches ``get_session_object``/``webhook_obj`` directly.
+    """
+    class _Controller:
+        def __init__(self):
+            self.get_calls = []
+            self.post_calls = []
+            self._get_resp = _FakeResponse()
+            self._post_resp = _FakeResponse()
+
+        def get_returns(self, resp):
+            self._get_resp = resp
+
+        def post_returns(self, resp):
+            self._post_resp = resp
+
+        def _get(self, *a, **k):
+            self.get_calls.append((a, k))
+            return self._get_resp
+
+        def _post(self, *a, **k):
+            self.post_calls.append((a, k))
+            return self._post_resp
+
+    ctrl = _Controller()
+    if hasattr(kce, "requests"):
+        monkeypatch.setattr(kce.requests, "get", ctrl._get, raising=False)
+        monkeypatch.setattr(kce.requests, "post", ctrl._post, raising=False)
+    return ctrl

--- a/tests/cover_extraction/test_cover_extraction.py
+++ b/tests/cover_extraction/test_cover_extraction.py
@@ -1,0 +1,473 @@
+"""Characterization tests for find_and_extract_cover, compress_image, convert_webp_to_jpg.
+
+These tests pin the CURRENT behavior of the production code.  When the behavior is
+surprising or potentially buggy, the assertion is labelled with a ``# FLAG:`` comment.
+All observed sentinel values were verified by running the functions in the .venv
+before writing each assertion.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import zipfile
+
+import pytest
+from PIL import Image
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_file(tmp_path, name: str, ext: str = ".cbz", root=None) -> kce.File:
+    """Build a minimal ``kce.File`` object pointing at ``<root>/<name>``."""
+    root = root or str(tmp_path)
+    extensionless = os.path.splitext(name)[0]
+    return kce.File(
+        name=name,
+        extensionless_name=extensionless,
+        basename=extensionless.split(" v")[0] if " v" in extensionless else extensionless,
+        extension=ext,
+        root=root,
+        path=os.path.join(root, name),
+        extensionless_path=os.path.join(root, extensionless),
+        volume_number=1.0,
+        file_type="volume",
+        header_extension=None,
+    )
+
+
+def _jpeg_bytes(color=(220, 50, 50), size=(4, 4)) -> bytes:
+    """Produce a real, decodable JPEG."""
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _png_bytes(color=(50, 200, 50), size=(4, 4)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _webp_bytes(color=(50, 100, 200), size=(4, 4)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, format="WEBP")
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# find_and_extract_cover — sentinel / return-type quad
+# ---------------------------------------------------------------------------
+
+class TestFindAndExtractCoverSentinels:
+    """Pin the four possible return values of find_and_extract_cover."""
+
+    def test_missing_file_returns_none(self, tmp_path):
+        """Non-existent path -> None (not False)."""
+        f = _make_file(tmp_path, "Missing v01.cbz")
+        # file does not exist on disk
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert result is None  # FLAG: None vs False distinction matters for callers
+
+    def test_not_a_zip_returns_none(self, tmp_path):
+        """File that exists but is not a zip -> None."""
+        p = tmp_path / "NotZip v01.cbz"
+        p.write_bytes(b"not a zip file at all")
+        f = _make_file(tmp_path, "NotZip v01.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert result is None  # FLAG: None, not False, for invalid zip
+
+    def test_zip_with_no_images_returns_false(self, tmp_path):
+        """Valid zip but no image entries -> False (not None)."""
+        p = tmp_path / "Empty v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("readme.txt", "no images here")
+        f = _make_file(tmp_path, "Empty v01.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert result is False  # FLAG: False, not None — callers using `if not result` lose the distinction
+
+    def test_zip_with_only_text_returns_false(self, tmp_path):
+        """Zip with only non-image extensions -> False."""
+        p = tmp_path / "TextOnly v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.txt", "just text")
+            zf.writestr("readme.md", "more text")
+        f = _make_file(tmp_path, "TextOnly v01.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert result is False
+
+    def test_success_returns_str_path(self, tmp_path):
+        """Successful extraction -> str path (not bytes, not bool)."""
+        p = tmp_path / "Series v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.jpg", _jpeg_bytes())
+        f = _make_file(tmp_path, "Series v01.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert isinstance(result, str)
+        assert result != ""
+
+    def test_success_cover_file_exists_on_disk(self, tmp_path):
+        """Returned path must actually exist on disk after a successful call."""
+        p = tmp_path / "Series v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.jpg", _jpeg_bytes())
+        f = _make_file(tmp_path, "Series v01.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert os.path.isfile(result)
+
+    def test_return_data_only_true_returns_bytes_on_success(self, tmp_path):
+        """return_data_only=True and archive has images -> bytes."""
+        p = tmp_path / "Series v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.jpg", _jpeg_bytes(size=(20, 20)))
+        f = _make_file(tmp_path, "Series v01.cbz")
+        result = kce.find_and_extract_cover(f, return_data_only=True, silent=True)
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_return_data_only_true_empty_archive_returns_false(self, tmp_path):
+        """return_data_only=True with no images -> still returns False, not None."""
+        p = tmp_path / "Empty v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("readme.txt", "no images")
+        f = _make_file(tmp_path, "Empty v01.cbz")
+        result = kce.find_and_extract_cover(f, return_data_only=True, silent=True)
+        assert result is False  # FLAG: False, same as the non-data mode
+
+
+# ---------------------------------------------------------------------------
+# find_and_extract_cover — output path behaviour
+# ---------------------------------------------------------------------------
+
+class TestFindAndExtractCoverOutputPath:
+    """Pin exact output path construction rules."""
+
+    def test_output_path_uses_extensionless_name_plus_jpg(self, tmp_path):
+        """Output file is placed in root/ with extensionless_name + original img ext."""
+        p = tmp_path / "My Series v03.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.jpg", _jpeg_bytes())
+        f = _make_file(tmp_path, "My Series v03.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        expected = os.path.join(str(tmp_path), "My Series v03.jpg")
+        assert result == expected
+
+    def test_jpeg_extension_normalized_to_jpg(self, tmp_path):
+        """.jpeg inside the archive -> output is .jpg (not .jpeg)."""
+        p = tmp_path / "JpegExt v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("cover.jpeg", _jpeg_bytes())
+        f = _make_file(tmp_path, "JpegExt v01.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert result is not None and result is not False
+        assert result.endswith(".jpg"), f"Expected .jpg but got: {result}"
+
+    def test_png_archive_image_gives_png_output(self, tmp_path):
+        """Image with .png extension inside -> output is .png."""
+        p = tmp_path / "PngCover v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.png", _png_bytes())
+        f = _make_file(tmp_path, "PngCover v01.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert result is not None and result is not False
+        assert result.endswith(".png"), f"Expected .png output but got: {result}"
+
+    def test_output_covers_as_webp_forces_webp_extension(self, tmp_path, monkeypatch):
+        """With output_covers_as_webp=True, output always has .webp extension."""
+        monkeypatch.setattr(kce, "output_covers_as_webp", True)
+        p = tmp_path / "WebpOut v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.jpg", _jpeg_bytes())
+        f = _make_file(tmp_path, "WebpOut v01.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert result is not None and result is not False
+        assert result.endswith(".webp"), f"Expected .webp output but got: {result}"
+
+    def test_directory_entries_in_zip_are_skipped(self, tmp_path):
+        """Zip entries ending in '/' are filtered; nested images still found."""
+        p = tmp_path / "DirEntry v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("images/", "")           # directory marker
+            zf.writestr("images/page_001.jpg", _jpeg_bytes())
+        f = _make_file(tmp_path, "DirEntry v01.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert isinstance(result, str)
+        assert os.path.isfile(result)
+
+
+# ---------------------------------------------------------------------------
+# find_and_extract_cover — cover pattern priority
+# ---------------------------------------------------------------------------
+
+class TestFindAndExtractCoverPatternPriority:
+    """Verify that cover-named images are matched by pattern priority."""
+
+    def test_cover_named_image_is_extracted(self, tmp_path):
+        """Archive containing 'cover.jpg' -> extraction succeeds."""
+        p = tmp_path / "Series v02.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.jpg", _jpeg_bytes(color=(100, 100, 100)))
+            zf.writestr("cover.jpg", _jpeg_bytes(color=(200, 200, 200)))
+            zf.writestr("page_002.jpg", _jpeg_bytes(color=(50, 50, 50)))
+        f = _make_file(tmp_path, "Series v02.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert isinstance(result, str)
+        assert os.path.isfile(result)
+
+
+# ---------------------------------------------------------------------------
+# find_and_extract_cover — blank image detection (gated setting)
+# ---------------------------------------------------------------------------
+
+class TestFindAndExtractCoverBlankDetection:
+    """Blank-image detection paths (only active when compare_detected_cover_to_blank_images=True)."""
+
+    def test_all_white_single_page_returns_false_when_blank_check_on(self, tmp_path, monkeypatch):
+        """A cbz with only a white-filled image -> False when blank check is enabled."""
+        monkeypatch.setattr(kce, "compare_detected_cover_to_blank_images", True)
+        # Build a white image that matches the blank_white.jpg reference well
+        white_buf = io.BytesIO()
+        Image.new("RGB", (100, 100), (255, 255, 255)).save(white_buf, "JPEG")
+        p = tmp_path / "AllWhite v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.jpg", white_buf.getvalue())
+        f = _make_file(tmp_path, "AllWhite v01.cbz")
+        result = kce.find_and_extract_cover(f, blank_image_check=True, silent=True)
+        assert result is False  # FLAG: white-only page detected as blank -> False
+
+    def test_blank_check_off_white_image_is_extracted(self, tmp_path, monkeypatch):
+        """Same white cbz but blank_image_check=False -> cover IS extracted (str returned)."""
+        monkeypatch.setattr(kce, "compare_detected_cover_to_blank_images", False)
+        white_buf = io.BytesIO()
+        Image.new("RGB", (100, 100), (255, 255, 255)).save(white_buf, "JPEG")
+        p = tmp_path / "WhiteOk v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.jpg", white_buf.getvalue())
+        f = _make_file(tmp_path, "WhiteOk v01.cbz")
+        result = kce.find_and_extract_cover(f, blank_image_check=False, silent=True)
+        assert isinstance(result, str)
+        assert os.path.isfile(result)
+
+
+# ---------------------------------------------------------------------------
+# find_and_extract_cover — multi-page archives
+# ---------------------------------------------------------------------------
+
+class TestFindAndExtractCoverMultiPage:
+    """Characterize behavior with 3 pages (as specified in the task prompt)."""
+
+    @pytest.mark.slow
+    def test_three_page_cbz_extracts_first_image_as_str(self, cbz_factory, tmp_path):
+        """cbz_factory(pages=3) -> extraction returns a str path."""
+        archive_path = cbz_factory(name="Series v01.cbz", pages=3)
+        f = _make_file(tmp_path, "Series v01.cbz", root=str(archive_path.parent))
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert isinstance(result, str)
+        assert os.path.isfile(result)
+
+    @pytest.mark.slow
+    def test_three_page_cbz_return_data_only_bytes(self, cbz_factory, tmp_path):
+        """cbz_factory(pages=3) + return_data_only=True -> bytes."""
+        archive_path = cbz_factory(name="Series v01.cbz", pages=3)
+        f = _make_file(tmp_path, "Series v01.cbz", root=str(archive_path.parent))
+        result = kce.find_and_extract_cover(f, return_data_only=True, silent=True)
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# find_and_extract_cover — compress_image_option interaction
+# ---------------------------------------------------------------------------
+
+class TestFindAndExtractCoverCompressInteraction:
+    """Verify that compress_image_option=True still returns str path (not raw bytes)."""
+
+    def test_compress_option_on_still_returns_str_path(self, tmp_path, monkeypatch):
+        """compress_image_option=True: result is str and file exists."""
+        monkeypatch.setattr(kce, "compress_image_option", True)
+        monkeypatch.setattr(kce, "image_quality", 40)
+        p = tmp_path / "Compressed v01.cbz"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("page_001.jpg", _jpeg_bytes(size=(100, 100)))
+        f = _make_file(tmp_path, "Compressed v01.cbz")
+        result = kce.find_and_extract_cover(f, silent=True)
+        assert isinstance(result, str)
+        assert os.path.isfile(result)
+
+
+# ---------------------------------------------------------------------------
+# compress_image — file-path mode
+# ---------------------------------------------------------------------------
+
+class TestCompressImageFileMode:
+    """Pin compress_image behavior when operating on a file path (no raw_data)."""
+
+    def test_jpeg_returns_str_path(self, tmp_path):
+        """compress_image on a JPEG file -> str path (same file, in-place)."""
+        p = tmp_path / "test.jpg"
+        Image.new("RGB", (50, 50), (200, 100, 50)).save(str(p), "JPEG")
+        result = kce.compress_image(str(p), quality=60)
+        assert isinstance(result, str)
+        assert result == str(p)
+
+    def test_jpeg_file_updated_in_place(self, tmp_path):
+        """After compression the path still exists and contains JPEG data."""
+        p = tmp_path / "test.jpg"
+        Image.new("RGB", (50, 50), (200, 100, 50)).save(str(p), "JPEG")
+        original_size = p.stat().st_size
+        result = kce.compress_image(str(p), quality=20)
+        assert os.path.isfile(result)
+        _ = original_size  # size may vary; just check file exists
+
+    def test_png_converted_to_jpg_removes_original(self, tmp_path):
+        """PNG input -> returns .jpg path; original .png is deleted."""
+        p = tmp_path / "test.png"
+        Image.new("RGB", (50, 50), (100, 200, 50)).save(str(p), "PNG")
+        assert p.exists()
+        result = kce.compress_image(str(p), quality=60)
+        assert isinstance(result, str)
+        assert result.endswith(".jpg")
+        assert not p.exists(), "Original PNG should have been deleted"
+        assert os.path.isfile(result)
+
+    def test_webp_file_stays_webp(self, tmp_path):
+        """WEBP input -> output is still .webp (no format change)."""
+        p = tmp_path / "test.webp"
+        Image.new("RGB", (50, 50), (50, 100, 200)).save(str(p), "WEBP")
+        result = kce.compress_image(str(p), quality=60)
+        assert isinstance(result, str)
+        assert result.endswith(".webp")
+        assert os.path.isfile(result)
+
+    def test_rgba_image_converted_to_rgb_then_saved(self, tmp_path):
+        """RGBA mode PNG -> compress_image converts to RGB and saves as JPEG."""
+        p = tmp_path / "rgba_test.png"
+        Image.new("RGBA", (50, 50), (200, 100, 50, 128)).save(str(p), "PNG")
+        result = kce.compress_image(str(p), quality=60)
+        assert isinstance(result, str)
+        assert result.endswith(".jpg")
+        assert os.path.isfile(result)
+
+    def test_palette_mode_converted_to_jpg(self, tmp_path):
+        """Palette (mode=P) PNG -> JPEG output returned."""
+        p = tmp_path / "palette.png"
+        Image.new("P", (50, 50)).save(str(p), "PNG")
+        result = kce.compress_image(str(p), quality=60)
+        assert isinstance(result, str)
+        assert result.endswith(".jpg")
+        assert os.path.isfile(result)
+
+    def test_to_jpg_flag_on_jpeg_file(self, tmp_path):
+        """to_jpg=True on an existing .jpg file -> same str path returned."""
+        p = tmp_path / "file.jpg"
+        Image.new("RGB", (50, 50), (100, 100, 100)).save(str(p), "JPEG")
+        result = kce.compress_image(str(p), quality=80, to_jpg=True)
+        assert isinstance(result, str)
+        assert result.endswith(".jpg")
+
+
+# ---------------------------------------------------------------------------
+# compress_image — raw_data mode
+# ---------------------------------------------------------------------------
+
+class TestCompressImageRawDataMode:
+    """Pin compress_image behavior when raw_data kwarg is provided."""
+
+    def test_raw_jpeg_data_returns_bytes(self, tmp_path):
+        """raw_data= with JPEG bytes -> returns bytes (not a path)."""
+        raw = _jpeg_bytes(size=(20, 20))
+        fake_path = os.path.join(str(tmp_path), "fake.jpg")
+        result = kce.compress_image(fake_path, quality=60, raw_data=raw)
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_raw_webp_data_returns_bytes(self, tmp_path):
+        """raw_data= with WEBP bytes -> returns bytes."""
+        raw = _webp_bytes(size=(20, 20))
+        fake_path = os.path.join(str(tmp_path), "fake.webp")
+        result = kce.compress_image(fake_path, quality=60, raw_data=raw)
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_raw_data_no_file_created(self, tmp_path):
+        """raw_data= mode must not create any files in tmp_path."""
+        raw = _jpeg_bytes(size=(20, 20))
+        fake_path = os.path.join(str(tmp_path), "should_not_appear.jpg")
+        before = set(os.listdir(str(tmp_path)))
+        kce.compress_image(fake_path, quality=60, raw_data=raw)
+        after = set(os.listdir(str(tmp_path)))
+        assert after == before, "raw_data mode should not write any file"
+
+    def test_raw_data_rgba_bytes_converted(self, tmp_path):
+        """RGBA raw data -> converted to RGB before compression; returns bytes."""
+        rgba_buf = io.BytesIO()
+        Image.new("RGBA", (20, 20), (200, 100, 50, 200)).save(rgba_buf, "PNG")
+        raw = rgba_buf.getvalue()
+        fake_path = os.path.join(str(tmp_path), "rgba.png")
+        result = kce.compress_image(fake_path, quality=60, raw_data=raw)
+        assert isinstance(result, bytes)
+
+
+# ---------------------------------------------------------------------------
+# convert_webp_to_jpg
+# ---------------------------------------------------------------------------
+
+class TestConvertWebpToJpg:
+    """Pin convert_webp_to_jpg return type and side-effects."""
+
+    def test_valid_webp_returns_jpg_path(self, tmp_path):
+        """Valid .webp file -> returns str path ending in .jpg."""
+        webp = tmp_path / "cover.webp"
+        Image.new("RGB", (50, 50), (100, 150, 200)).save(str(webp), "WEBP")
+        result = kce.convert_webp_to_jpg(str(webp))
+        assert isinstance(result, str)
+        assert result.endswith(".jpg")
+
+    def test_valid_webp_jpg_file_exists(self, tmp_path):
+        """After conversion the .jpg file is present on disk."""
+        webp = tmp_path / "cover.webp"
+        Image.new("RGB", (50, 50), (100, 150, 200)).save(str(webp), "WEBP")
+        result = kce.convert_webp_to_jpg(str(webp))
+        assert os.path.isfile(result)
+
+    def test_valid_webp_original_deleted(self, tmp_path):
+        """Source .webp file is removed after successful conversion."""
+        webp = tmp_path / "cover.webp"
+        Image.new("RGB", (50, 50), (100, 150, 200)).save(str(webp), "WEBP")
+        kce.convert_webp_to_jpg(str(webp))
+        assert not webp.exists(), "Original .webp should be deleted on success"
+
+    def test_none_input_returns_none(self):
+        """None input -> returns None immediately."""
+        result = kce.convert_webp_to_jpg(None)
+        assert result is None
+
+    def test_empty_string_returns_none(self):
+        """Empty string input -> returns None (falsy guard)."""
+        result = kce.convert_webp_to_jpg("")
+        assert result is None
+
+    def test_nonexistent_path_returns_none(self):
+        """Path that doesn't exist on disk -> exception caught, returns None."""
+        result = kce.convert_webp_to_jpg("/nonexistent/no_such_file.webp")
+        assert result is None
+
+    def test_jpg_path_derived_from_webp_stem(self, tmp_path):
+        """Output path is exactly <stem>.jpg (same directory, same stem)."""
+        webp = tmp_path / "my_cover.webp"
+        Image.new("RGB", (10, 10), (10, 20, 30)).save(str(webp), "WEBP")
+        result = kce.convert_webp_to_jpg(str(webp))
+        expected = str(tmp_path / "my_cover.jpg")
+        assert result == expected
+
+    def test_converted_jpg_is_readable(self, tmp_path):
+        """The produced .jpg file can be opened by PIL without error."""
+        webp = tmp_path / "readable.webp"
+        Image.new("RGB", (20, 20), (200, 200, 100)).save(str(webp), "WEBP")
+        result = kce.convert_webp_to_jpg(str(webp))
+        with Image.open(result) as img:
+            assert img.format == "JPEG"

--- a/tests/cover_extraction/test_image_bw.py
+++ b/tests/cover_extraction/test_image_bw.py
@@ -1,0 +1,201 @@
+"""Characterization tests for is_image_black_and_white.
+
+Pins the EXACT behaviour observed in .venv on 2026-06-08.
+
+Signature (read from source, lines 3339-3360):
+    is_image_black_and_white(image: PIL.Image.Image, tolerance: int = 15) -> bool
+
+Algorithm:
+    Convert image to RGB, split R/G/B channels, compute mean of
+    |R-G| (via ImageChops.difference) and mean of |G-B|.
+    Return True iff BOTH means <= tolerance.
+
+Observations logged below each test were captured by running the real
+function in .venv before writing the assertion.
+
+# FLAG: notes are added wherever behaviour is surprising / non-obvious.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _save_and_open(img: Image.Image, tmp_path, name: str = "img.png") -> Image.Image:
+    """Round-trip through disk so the image is a 'real' file-backed Image."""
+    p = tmp_path / name
+    img.save(str(p))
+    return Image.open(str(p))
+
+
+# ---------------------------------------------------------------------------
+# Solid-colour images (pure characterization)
+# ---------------------------------------------------------------------------
+
+class TestSolidColors:
+    """Each solid colour is passed directly as a PIL Image (function takes Image,
+    not a path — confirmed from the source signature)."""
+
+    def test_solid_white_is_bw(self, tiny_image):
+        # Observed: True (mean_rg=0, mean_gb=0 — both well within tolerance=15)
+        img = tiny_image(color=(255, 255, 255), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img) is True
+
+    def test_solid_black_is_bw(self, tiny_image):
+        # Observed: True (all channels identical -> differences are 0)
+        img = tiny_image(color=(0, 0, 0), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img) is True
+
+    def test_mid_gray_is_bw(self, tiny_image):
+        # Observed: True (R=G=B=128, differences all zero)
+        img = tiny_image(color=(128, 128, 128), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img) is True
+
+    def test_saturated_red_is_not_bw(self, tiny_image):
+        # Observed: False (mean_rg=255, mean_gb=0 -> mean_rg >> 15)
+        img = tiny_image(color=(255, 0, 0), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img) is False
+
+    def test_saturated_green_is_not_bw(self, tiny_image):
+        # Observed: False (mean_rg=255, mean_gb=255)
+        img = tiny_image(color=(0, 255, 0), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img) is False
+
+    def test_saturated_blue_is_not_bw(self, tiny_image):
+        # Observed: False (mean_rg=0, mean_gb=255)
+        img = tiny_image(color=(0, 0, 255), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img) is False
+
+    def test_1x1_solid_red_is_not_bw(self):
+        # Observed: False — tiny image, same logic applies
+        img = Image.new("RGB", (1, 1), (255, 0, 0))
+        assert kce.is_image_black_and_white(img) is False
+
+
+# ---------------------------------------------------------------------------
+# Tolerance boundary tests
+# ---------------------------------------------------------------------------
+
+class TestToleranceBoundary:
+    """The default tolerance is 15 (inclusive on both ends)."""
+
+    def test_near_gray_within_tolerance_is_bw(self, tiny_image):
+        # (128, 120, 115): mean_rg=8, mean_gb=5 — both <= 15 -> True
+        img = tiny_image(color=(128, 120, 115), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img) is True
+
+    def test_at_tolerance_boundary_is_bw(self, tiny_image):
+        # (128, 113, 98): mean_rg=15, mean_gb=15 — exactly == 15 -> True
+        # FLAG: boundary is INCLUSIVE (<=), so 15 == 15 passes.
+        img = tiny_image(color=(128, 113, 98), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img) is True
+
+    def test_over_tolerance_boundary_is_not_bw(self, tiny_image):
+        # (128, 112, 97): mean_rg=16, mean_gb=15 — mean_rg > 15 -> False
+        img = tiny_image(color=(128, 112, 97), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img) is False
+
+    def test_custom_tolerance_zero_pure_gray(self, tiny_image):
+        # Pure gray (R=G=B=128) with tolerance=0: differences are all 0 -> True
+        img = tiny_image(color=(128, 128, 128), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img, tolerance=0) is True
+
+    def test_custom_tolerance_zero_near_gray_fails(self, tiny_image):
+        # (128, 120, 115) with tolerance=0: mean_rg=8 > 0 -> False
+        img = tiny_image(color=(128, 120, 115), size=(4, 4), mode="RGB")
+        assert kce.is_image_black_and_white(img, tolerance=0) is False
+
+
+# ---------------------------------------------------------------------------
+# Image mode handling (L, RGBA, etc.)
+# ---------------------------------------------------------------------------
+
+class TestImageModes:
+    """The function converts to RGB internally, so other modes should work."""
+
+    def test_l_mode_grayscale_is_bw(self):
+        # L-mode (8-bit grayscale) mid-gray -> after convert('RGB'), R=G=B -> True
+        # Observed: True
+        img = Image.new("L", (4, 4), 128)
+        assert kce.is_image_black_and_white(img) is True
+
+    def test_rgba_gray_is_bw(self):
+        # RGBA mid-gray with alpha; convert('RGB') drops alpha -> R=G=B -> True
+        # Observed: True
+        img = Image.new("RGBA", (4, 4), (200, 200, 200, 128))
+        assert kce.is_image_black_and_white(img) is True
+
+    def test_rgba_red_is_not_bw(self):
+        # RGBA saturated red — even after convert('RGB'), R>>G -> False
+        img = Image.new("RGBA", (4, 4), (255, 0, 0, 255))
+        assert kce.is_image_black_and_white(img) is False
+
+
+# ---------------------------------------------------------------------------
+# Mixed-pixel images
+# ---------------------------------------------------------------------------
+
+class TestMixedPixels:
+    """Mean difference is computed over all pixels; a partial colour area can
+    push the mean above tolerance."""
+
+    def test_half_red_half_white_is_not_bw(self):
+        # 10×10 image: left 5 cols = red (255,0,0), right 5 cols = white (255,255,255)
+        # mean_rg = mean(|255-0|*50 + |255-255|*50) / 100 = 127.5 > 15 -> False
+        # Observed: False
+        img = Image.new("RGB", (10, 10), (255, 255, 255))
+        for x in range(5):
+            for y in range(10):
+                img.putpixel((x, y), (255, 0, 0))
+        assert kce.is_image_black_and_white(img) is False
+
+
+# ---------------------------------------------------------------------------
+# Repo reference blank images
+# ---------------------------------------------------------------------------
+
+class TestRepoBlanks:
+    """Pin behaviour on the actual blank cover images shipped with the repo.
+    These files are used by the blank-image-detection pipeline."""
+
+    def test_blank_white_jpg_is_bw(self, blank_image_paths):
+        # blank_white.jpg: a plain white JPEG -> Observed: True
+        img = Image.open(blank_image_paths["white"])
+        assert kce.is_image_black_and_white(img) is True
+
+    def test_blank_black_png_is_bw(self, blank_image_paths):
+        # blank_black.png: a plain black PNG -> Observed: True
+        img = Image.open(blank_image_paths["black"])
+        assert kce.is_image_black_and_white(img) is True
+
+
+# ---------------------------------------------------------------------------
+# Disk-backed images (saved to tmp_path, then reopened)
+# ---------------------------------------------------------------------------
+
+class TestDiskBacked:
+    """Verify results are identical whether the Image was constructed in-memory
+    or round-tripped through disk (save -> open)."""
+
+    def test_white_roundtrip_png_is_bw(self, tmp_path):
+        img = Image.new("RGB", (8, 8), (255, 255, 255))
+        saved = _save_and_open(img, tmp_path, "white.png")
+        assert kce.is_image_black_and_white(saved) is True
+
+    def test_red_roundtrip_jpg_is_not_bw(self, tmp_path):
+        # JPEG compression may alter pixel values slightly, but saturated red
+        # remains far above the tolerance threshold.
+        img = Image.new("RGB", (8, 8), (255, 0, 0))
+        p = tmp_path / "red.jpg"
+        img.save(str(p), format="JPEG", quality=95)
+        saved = Image.open(str(p))
+        assert kce.is_image_black_and_white(saved) is False

--- a/tests/cover_extraction/test_image_similarity.py
+++ b/tests/cover_extraction/test_image_similarity.py
@@ -1,0 +1,356 @@
+"""Characterization tests for image similarity functions in komga_cover_extractor.
+
+These tests pin the *exact* observed behavior of:
+  - preprocess_image(image)   -> imagehash.ImageHash (64-bit pHash)
+  - compare_images(a, b, silent=False) -> float in [0, 1]
+  - prep_images_for_similarity(blank_image_path, internal_cover_data,
+                                both_cover_data=False, silent=False) -> float
+
+Key characterization findings (all FLAG comments below document known
+mis-calibration artifacts — DO NOT FIX in this PR):
+
+  * phash collapses every solid-color image (white, red, green, blue, grey)
+    to the same 64-bit hash (8000000000000000), so their pairwise similarity
+    scores are all 1.0.  This means the blank-detection threshold
+    (blank_cover_required_similarity_score = 0.9) cannot distinguish a solid
+    red cover from a blank white page.
+
+  * The repo blank_white.jpg and blank_black.png differ by exactly 1 bit of
+    Hamming distance, giving similarity = 1 - 1/64 = 0.984375.  Any threshold
+    below ~0.985 would flag *both* as matches when checking against either.
+"""
+
+from __future__ import annotations
+
+import io
+
+import imagehash
+import pytest
+from PIL import Image
+
+import komga_cover_extractor as kce
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _solid_jpeg_bytes(color: tuple[int, int, int], size: tuple[int, int] = (100, 100)) -> bytes:
+    """Create a solid-colour JPEG as raw bytes (100x100 by default)."""
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _solid_pil(color: tuple[int, int, int], size: tuple[int, int] = (100, 100)) -> Image.Image:
+    """Return an in-memory PIL Image of a single solid colour."""
+    return Image.new("RGB", size, color)
+
+
+# ---------------------------------------------------------------------------
+# preprocess_image
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+class TestPreprocessImage:
+    """preprocess_image(image: PIL.Image) -> imagehash.ImageHash"""
+
+    def test_returns_imagehash_type(self):
+        img = _solid_pil((255, 255, 255))
+        result = kce.preprocess_image(img)
+        assert isinstance(result, imagehash.ImageHash)
+
+    def test_white_hash_value(self):
+        # Solid white 100x100 -> pHash = 8000000000000000 (hex string form)
+        img = _solid_pil((255, 255, 255))
+        h = kce.preprocess_image(img)
+        assert str(h) == "8000000000000000"
+
+    def test_black_hash_value(self):
+        # Solid black 100x100 -> pHash = 0000000000000000
+        img = _solid_pil((0, 0, 0))
+        h = kce.preprocess_image(img)
+        assert str(h) == "0000000000000000"
+
+    def test_red_hash_value(self):
+        # FLAG: solid red collapses to the SAME hash as solid white (8000000000000000).
+        # This is the phash mis-calibration: chrominance information is lost
+        # because phash only operates on the luma/grayscale channel.
+        img = _solid_pil((255, 0, 0))
+        h = kce.preprocess_image(img)
+        assert str(h) == "8000000000000000"  # FLAG: identical to white
+
+    def test_green_hash_value(self):
+        # FLAG: same as white and red
+        img = _solid_pil((0, 255, 0))
+        h = kce.preprocess_image(img)
+        assert str(h) == "8000000000000000"  # FLAG: identical to white
+
+    def test_blue_hash_value(self):
+        # FLAG: same as white
+        img = _solid_pil((0, 0, 255))
+        h = kce.preprocess_image(img)
+        assert str(h) == "8000000000000000"  # FLAG: identical to white
+
+    def test_grey_hash_value(self):
+        # FLAG: grey (128,128,128) also hashes identical to white
+        img = _solid_pil((128, 128, 128))
+        h = kce.preprocess_image(img)
+        assert str(h) == "8000000000000000"  # FLAG: identical to white
+
+    def test_different_image_sizes_are_tolerated(self):
+        # phash internally resizes, so different dimensions produce the same
+        # hash for the same uniform colour.
+        small = _solid_pil((255, 255, 255), size=(16, 16))
+        large = _solid_pil((255, 255, 255), size=(500, 700))
+        assert str(kce.preprocess_image(small)) == str(kce.preprocess_image(large))
+
+
+# ---------------------------------------------------------------------------
+# compare_images
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+class TestCompareImages:
+    """compare_images(imageA, imageB, silent=False) -> float
+
+    Both arguments must be imagehash.ImageHash objects.
+    """
+
+    def test_identical_hashes_return_1_0(self):
+        img = _solid_pil((255, 255, 255))
+        h = kce.preprocess_image(img)
+        score = kce.compare_images(h, h, silent=True)
+        assert score == 1.0
+
+    def test_return_type_is_float(self):
+        img = _solid_pil((200, 200, 200))
+        h = kce.preprocess_image(img)
+        score = kce.compare_images(h, h, silent=True)
+        assert isinstance(score, float)
+
+    def test_white_vs_black_solid(self):
+        # Solid white (8000000000000000) vs solid black (0000000000000000):
+        # Hamming distance = 1, similarity = 1 - 1/64 = 0.984375
+        white_hash = kce.preprocess_image(_solid_pil((255, 255, 255)))
+        black_hash = kce.preprocess_image(_solid_pil((0, 0, 0)))
+        score = kce.compare_images(white_hash, black_hash, silent=True)
+        assert score == 0.984375
+
+    def test_identical_white_images(self):
+        h1 = kce.preprocess_image(_solid_pil((255, 255, 255)))
+        h2 = kce.preprocess_image(_solid_pil((255, 255, 255)))
+        assert kce.compare_images(h1, h2, silent=True) == 1.0
+
+    def test_identical_black_images(self):
+        h1 = kce.preprocess_image(_solid_pil((0, 0, 0)))
+        h2 = kce.preprocess_image(_solid_pil((0, 0, 0)))
+        assert kce.compare_images(h1, h2, silent=True) == 1.0
+
+    def test_white_vs_red(self):
+        # FLAG: white and red both hash to 8000000000000000, so similarity is 1.0.
+        # This means the blank-detection code cannot distinguish a solid-red cover
+        # from a blank white page when using pHash alone.
+        white_hash = kce.preprocess_image(_solid_pil((255, 255, 255)))
+        red_hash = kce.preprocess_image(_solid_pil((255, 0, 0)))
+        score = kce.compare_images(white_hash, red_hash, silent=True)
+        assert score == 1.0  # FLAG: mis-calibration
+
+    def test_white_vs_green(self):
+        # FLAG: same mis-calibration as red
+        white_hash = kce.preprocess_image(_solid_pil((255, 255, 255)))
+        green_hash = kce.preprocess_image(_solid_pil((0, 255, 0)))
+        assert kce.compare_images(white_hash, green_hash, silent=True) == 1.0  # FLAG: mis-calibration
+
+    def test_white_vs_blue(self):
+        # FLAG: same mis-calibration
+        white_hash = kce.preprocess_image(_solid_pil((255, 255, 255)))
+        blue_hash = kce.preprocess_image(_solid_pil((0, 0, 255)))
+        assert kce.compare_images(white_hash, blue_hash, silent=True) == 1.0  # FLAG: mis-calibration
+
+    def test_white_vs_grey(self):
+        # FLAG: grey (128,128,128) produces the same hash as white
+        white_hash = kce.preprocess_image(_solid_pil((255, 255, 255)))
+        grey_hash = kce.preprocess_image(_solid_pil((128, 128, 128)))
+        assert kce.compare_images(white_hash, grey_hash, silent=True) == 1.0  # FLAG: mis-calibration
+
+    def test_invalid_arg_returns_0(self):
+        # compare_images catches exceptions and returns 0 on error.
+        h = kce.preprocess_image(_solid_pil((255, 255, 255)))
+        result = kce.compare_images(h, "not_a_hash", silent=True)
+        assert result == 0
+
+    def test_score_range(self):
+        # All scores should be in [0, 1]
+        h1 = kce.preprocess_image(_solid_pil((255, 0, 0)))
+        h2 = kce.preprocess_image(_solid_pil((0, 0, 0)))
+        score = kce.compare_images(h1, h2, silent=True)
+        assert 0.0 <= score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# prep_images_for_similarity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+class TestPrepImagesForSimilarity:
+    """prep_images_for_similarity(blank_image_path, internal_cover_data,
+                                   both_cover_data=False, silent=False) -> float
+
+    When both_cover_data=False: blank_image_path is a filesystem path (str),
+      internal_cover_data is raw image bytes.
+    When both_cover_data=True: blank_image_path is also raw image bytes,
+      internal_cover_data is raw image bytes.
+    """
+
+    def test_return_type_is_float(self, blank_image_paths):
+        white_bytes = _solid_jpeg_bytes((255, 255, 255))
+        result = kce.prep_images_for_similarity(
+            blank_image_paths["white"], white_bytes, silent=True
+        )
+        assert isinstance(result, float)
+
+    def test_identical_images_both_bytes(self):
+        # both_cover_data=True: both args are bytes; identical -> 1.0
+        white_bytes = _solid_jpeg_bytes((255, 255, 255))
+        score = kce.prep_images_for_similarity(
+            white_bytes, white_bytes, both_cover_data=True, silent=True
+        )
+        assert score == 1.0
+
+    def test_identical_white_vs_white_path(self, blank_image_paths):
+        # blank_image_path=repo blank_white.jpg, cover data=same file bytes
+        with open(blank_image_paths["white"], "rb") as f:
+            white_file_bytes = f.read()
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["white"], white_file_bytes, silent=True
+        )
+        assert score == 1.0
+
+    def test_identical_black_vs_black_path(self, blank_image_paths):
+        # blank_image_path=repo blank_black.png, cover data=same file bytes
+        with open(blank_image_paths["black"], "rb") as f:
+            black_file_bytes = f.read()
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["black"], black_file_bytes, silent=True
+        )
+        assert score == 1.0
+
+    def test_blank_white_vs_blank_black_both_bytes(self, blank_image_paths):
+        # FLAG (headline mis-calibration): blank_white.jpg vs blank_black.png
+        # differ by exactly 1 bit -> similarity = 1 - 1/64 = 0.984375.
+        # This is above the default threshold (0.9), so both would be flagged
+        # as blank when checking against EITHER reference image.
+        with open(blank_image_paths["white"], "rb") as f:
+            white_bytes = f.read()
+        with open(blank_image_paths["black"], "rb") as f:
+            black_bytes = f.read()
+        score = kce.prep_images_for_similarity(
+            white_bytes, black_bytes, both_cover_data=True, silent=True
+        )
+        assert score == 0.984375  # FLAG: white vs black similarity unexpectedly high
+
+    def test_solid_red_vs_blank_white_path(self, blank_image_paths):
+        # FLAG: solid red is scored as 1.0 similar to blank white because phash
+        # collapses all solid colours with the same luminance to the same hash.
+        # blank_cover_required_similarity_score=0.9 would therefore flag solid
+        # red covers as blank — this threshold needs re-tuning.
+        red_bytes = _solid_jpeg_bytes((255, 0, 0))
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["white"], red_bytes, silent=True
+        )
+        assert score == 1.0  # FLAG: mis-calibration — red reads as perfect blank match
+
+    def test_solid_green_vs_blank_white_path(self, blank_image_paths):
+        # FLAG: same mis-calibration as red
+        green_bytes = _solid_jpeg_bytes((0, 255, 0))
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["white"], green_bytes, silent=True
+        )
+        assert score == 1.0  # FLAG: mis-calibration
+
+    def test_solid_blue_vs_blank_white_path(self, blank_image_paths):
+        # FLAG: same mis-calibration as red and green
+        blue_bytes = _solid_jpeg_bytes((0, 0, 255))
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["white"], blue_bytes, silent=True
+        )
+        assert score == 1.0  # FLAG: mis-calibration
+
+    def test_solid_grey_vs_blank_white_path(self, blank_image_paths):
+        # FLAG: grey (128,128,128) also reads as a perfect match for blank white
+        grey_bytes = _solid_jpeg_bytes((128, 128, 128))
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["white"], grey_bytes, silent=True
+        )
+        assert score == 1.0  # FLAG: mis-calibration
+
+    def test_solid_red_vs_blank_black_path(self, blank_image_paths):
+        # Solid red hash = 8000000000000000, black blank hash = 0000000000000000
+        # -> Hamming = 1, similarity = 0.984375
+        # Still above the 0.9 threshold — would be flagged as blank vs black too.
+        red_bytes = _solid_jpeg_bytes((255, 0, 0))
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["black"], red_bytes, silent=True
+        )
+        assert score == 0.984375  # FLAG: mis-calibration
+
+    def test_solid_green_vs_blank_black_path(self, blank_image_paths):
+        green_bytes = _solid_jpeg_bytes((0, 255, 0))
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["black"], green_bytes, silent=True
+        )
+        assert score == 0.984375  # FLAG: mis-calibration
+
+    def test_solid_blue_vs_blank_black_path(self, blank_image_paths):
+        blue_bytes = _solid_jpeg_bytes((0, 0, 255))
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["black"], blue_bytes, silent=True
+        )
+        assert score == 0.984375  # FLAG: mis-calibration
+
+    def test_solid_grey_vs_blank_black_path(self, blank_image_paths):
+        grey_bytes = _solid_jpeg_bytes((128, 128, 128))
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["black"], grey_bytes, silent=True
+        )
+        assert score == 0.984375  # FLAG: mis-calibration
+
+    def test_solid_black_vs_blank_black_path(self, blank_image_paths):
+        # Solid black image == blank black reference -> similarity 1.0
+        black_bytes = _solid_jpeg_bytes((0, 0, 0))
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["black"], black_bytes, silent=True
+        )
+        assert score == 1.0
+
+    def test_solid_black_vs_blank_white_path(self, blank_image_paths):
+        # Solid black vs blank white -> Hamming 1 -> 0.984375
+        black_bytes = _solid_jpeg_bytes((0, 0, 0))
+        score = kce.prep_images_for_similarity(
+            blank_image_paths["white"], black_bytes, silent=True
+        )
+        assert score == 0.984375
+
+    def test_uses_cached_white_hash(self):
+        # When blank_image_path matches blank_white_image_path, the precomputed
+        # blank_white_image_hash is used (branch: elif blank_image_path ==
+        # blank_white_image_path and blank_white_image_hash).
+        # Verify: result is the same as computing fresh.
+        white_bytes = _solid_jpeg_bytes((255, 255, 255))
+        score_cached = kce.prep_images_for_similarity(
+            kce.blank_white_image_path, white_bytes, silent=True
+        )
+        # Compute fresh to cross-check
+        fresh_hash = kce.preprocess_image(Image.open(io.BytesIO(white_bytes)))
+        score_fresh = kce.compare_images(kce.blank_white_image_hash, fresh_hash, silent=True)
+        assert score_cached == score_fresh
+
+    def test_uses_cached_black_hash(self):
+        # Similarly for blank_black_image_path.
+        black_bytes = _solid_jpeg_bytes((0, 0, 0))
+        score_cached = kce.prep_images_for_similarity(
+            kce.blank_black_image_path, black_bytes, silent=True
+        )
+        fresh_hash = kce.preprocess_image(Image.open(io.BytesIO(black_bytes)))
+        score_fresh = kce.compare_images(kce.blank_black_image_hash, fresh_hash, silent=True)
+        assert score_cached == score_fresh

--- a/tests/engine/test_index_equality.py
+++ b/tests/engine/test_index_equality.py
@@ -1,0 +1,249 @@
+"""Characterization tests for is_same_index_number — the dedup equality contract.
+
+These tests pin what the production code does TODAY — surprises and all.
+Any FLAG: comment documents a known quirk or potential bug that is pinned as-is.
+
+Verified with: .venv/bin/python3 -c "import komga_cover_extractor as kce; ..." on the
+tests/upgrade-scoring-engine branch (commit after 300cfb4).
+
+Function source (komga_cover_extractor.py ~line 2475):
+
+    def is_same_index_number(index_one, index_two, allow_array_match=False):
+        if (index_one == index_two and index_one != "") or (
+            allow_array_match
+            and (
+                (isinstance(index_one, list) and index_two in index_one)
+                or (isinstance(index_two, list) and index_one in index_two)
+            )
+        ):
+            return True
+        return False
+
+Key observations:
+- Return type is always plain bool (True / False).
+- Empty string ``""`` is the one sentinel excluded: ``"" == ""`` is False because
+  the guard ``index_one != ""`` fails for empty strings.
+- None passes the guard (None != "" is True), so None == None -> True.
+- allow_array_match only fires for list, NOT tuple — a tuple operand returns False
+  even if the element is present (the ``isinstance(..., list)`` guard).  This is a
+  latent hazard downstream of get_release_number which can return a tuple for
+  multi-number ranges.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+f = kce.is_same_index_number   # shorthand used throughout
+
+
+# ---------------------------------------------------------------------------
+# Basic equality — no allow_array_match
+# ---------------------------------------------------------------------------
+
+
+class TestBasicEquality:
+    """Two scalar operands, allow_array_match=False (default)."""
+
+    def test_equal_ints_returns_true(self):
+        """Same integer values are equal."""
+        assert f(1, 1) is True
+
+    def test_unequal_ints_returns_false(self):
+        """Different integers are not equal."""
+        assert f(1, 2) is False
+
+    def test_zero_zero_returns_true(self):
+        """Integer zero is a valid, equal index (not treated as falsy sentinel)."""
+        assert f(0, 0) is True
+
+    def test_zero_one_returns_false(self):
+        assert f(0, 1) is False
+
+    def test_equal_floats_returns_true(self):
+        """Float volumes like 1.5 == 1.5."""
+        assert f(1.5, 1.5) is True
+
+    def test_unequal_floats_returns_false(self):
+        assert f(1.5, 2.5) is False
+
+    def test_int_one_float_one_returns_true(self):
+        """Python equality: 1 == 1.0 is True, and 1 != '' -> condition passes."""
+        assert f(1, 1.0) is True
+
+    def test_float_one_int_one_returns_true(self):
+        assert f(1.0, 1) is True
+
+    def test_int_one_float_one_point_five_returns_false(self):
+        """1 != 1.5 in Python."""
+        assert f(1, 1.5) is False
+
+    def test_equal_strings_returns_true(self):
+        """Non-empty strings compare equal."""
+        assert f("abc", "abc") is True
+
+    def test_unequal_strings_returns_false(self):
+        assert f("abc", "xyz") is False
+
+    def test_return_type_is_bool_true(self):
+        """Return value is exactly bool, not a truthy/falsy object."""
+        result = f(1, 1)
+        assert isinstance(result, bool)
+        assert result is True
+
+    def test_return_type_is_bool_false(self):
+        result = f(1, 2)
+        assert isinstance(result, bool)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Empty-string sentinel — the one excluded value
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyStringSentinel:
+    """Empty string is explicitly excluded: '' == '' returns False.
+
+    This is the code's way of expressing "not yet parsed / unknown" —
+    two unknown indices must not be treated as duplicates.
+    """
+
+    def test_empty_empty_returns_false(self):
+        # FLAG: '' == '' is True in Python, but the guard ``index_one != ""``
+        # short-circuits the condition, so the function returns False.
+        assert f("", "") is False
+
+    def test_empty_nonempty_returns_false(self):
+        assert f("", "abc") is False
+
+    def test_nonempty_empty_returns_false(self):
+        assert f("abc", "") is False
+
+    def test_zero_empty_returns_false(self):
+        """0 != "" is True in Python, but 0 != "" and 0 == "" -> 0 == "" is False."""
+        assert f(0, "") is False
+
+    def test_empty_zero_returns_false(self):
+        assert f("", 0) is False
+
+
+# ---------------------------------------------------------------------------
+# None behavior — passes the sentinel guard (None != '' is True)
+# ---------------------------------------------------------------------------
+
+
+class TestNoneBehavior:
+    """None passes the guard because None != '' evaluates to True."""
+
+    def test_none_none_returns_true(self):
+        # FLAG: None == None and None != '' -> True.  Two "missing" indices
+        # are thus considered the same, which may or may not be intentional.
+        assert f(None, None) is True
+
+    def test_none_int_returns_false(self):
+        assert f(None, 1) is False
+
+    def test_int_none_returns_false(self):
+        assert f(1, None) is False
+
+
+# ---------------------------------------------------------------------------
+# allow_array_match=True with list — the happy path
+# ---------------------------------------------------------------------------
+
+
+class TestAllowArrayMatchWithList:
+    """allow_array_match=True triggers only for list, not any other sequence type."""
+
+    def test_scalar_in_list_second_arg_returns_true(self):
+        """index_one is in the list passed as index_two."""
+        assert f(1, [1, 3], allow_array_match=True) is True
+
+    def test_scalar_in_list_first_arg_returns_true(self):
+        """index_two is in the list passed as index_one."""
+        assert f([1, 3], 1, allow_array_match=True) is True
+
+    def test_scalar_not_in_list_second_arg_returns_false(self):
+        assert f(2, [1, 3], allow_array_match=True) is False
+
+    def test_scalar_not_in_list_first_arg_returns_false(self):
+        assert f([1, 3], 2, allow_array_match=True) is False
+
+    def test_allow_array_match_false_with_list_returns_false(self):
+        """With allow_array_match=False, list membership is NOT checked."""
+        assert f(1, [1, 3], allow_array_match=False) is False
+
+    def test_allow_array_match_default_with_list_returns_false(self):
+        """Default allow_array_match=False: list membership is NOT checked."""
+        assert f(1, [1, 3]) is False
+
+    def test_both_lists_equal_no_allow_array_match_returns_true(self):
+        """Two equal list objects still satisfy index_one == index_two (list __eq__)."""
+        assert f([1, 2], [1, 2], False) is True
+
+    def test_both_lists_equal_allow_array_match_returns_true(self):
+        """Equal lists: the first condition (==) fires before allow_array_match check."""
+        assert f([1, 2], [1, 2], True) is True
+
+    def test_empty_list_scalar_returns_false(self):
+        """Empty list: membership test on [] always fails."""
+        assert f(1, [], allow_array_match=True) is False
+
+    def test_scalar_empty_list_returns_false(self):
+        assert f([], 1, allow_array_match=True) is False
+
+    def test_none_in_list_with_none_returns_true(self):
+        """None can be found inside a list when allow_array_match=True."""
+        assert f(None, [None, 1], allow_array_match=True) is True
+
+    def test_none_not_in_list_returns_false(self):
+        assert f(None, [1, 2], allow_array_match=True) is False
+
+
+# ---------------------------------------------------------------------------
+# allow_array_match=True with TUPLE — the latent dedup hazard
+# ---------------------------------------------------------------------------
+
+
+class TestAllowArrayMatchTupleHazard:
+    """Tuples are NOT recognised by allow_array_match — isinstance(..., list) rejects them.
+
+    get_release_number can return a *tuple* for multi-number ranges (e.g. (1, 3)).
+    If that tuple is passed here with allow_array_match=True the membership check
+    is silently skipped and False is returned even when the element is present.
+    This is a real dedup gap and is pinned as-is.
+    """
+
+    def test_scalar_in_tuple_second_arg_returns_false(self):
+        # FLAG: (1, (1, 3), allow_array_match=True) -> False.
+        # A list [1, 3] would return True, but a tuple (1, 3) does NOT because
+        # isinstance((1, 3), list) is False.  Downstream dedup comparisons that
+        # receive a tuple from get_release_number will silently fail to match.
+        assert f(1, (1, 3), allow_array_match=True) is False
+
+    def test_scalar_in_tuple_first_arg_returns_false(self):
+        # FLAG: ((1, 3), 1, allow_array_match=True) -> False.
+        # The isinstance check on index_one also requires list, so a tuple in
+        # the first position likewise fails.
+        assert f((1, 3), 1, allow_array_match=True) is False
+
+    def test_tuple_with_allow_array_match_false_returns_false(self):
+        """Sanity: tuple still fails when allow_array_match is False too."""
+        assert f(1, (1, 3), allow_array_match=False) is False
+
+    def test_list_vs_tuple_asymmetry(self):
+        """Demonstrates the list/tuple asymmetry explicitly in one test.
+
+        list  -> membership check fires  -> True
+        tuple -> membership check skipped -> False
+        """
+        assert f(1, [1, 3], allow_array_match=True) is True   # list: True
+        assert f(1, (1, 3), allow_array_match=True) is False  # tuple: False

--- a/tests/engine/test_premium_subtitle.py
+++ b/tests/engine/test_premium_subtitle.py
@@ -1,0 +1,457 @@
+"""Characterization tests for ``kce.contains_premium_content`` and
+``kce.get_subtitle_from_title``.
+
+All assertions were verified against real function output observed in
+``.venv/bin/python3`` before writing — see inline comments for the
+exact observed values.
+
+Verified function signatures (via Serena, komga_cover_extractor.py):
+
+  contains_premium_content(file)
+      Opens *file* as a zipfile and checks for three independent premium signals:
+        1. ``bonus.xhtml`` (or ``bonus_N.xhtml``) member exists AND a member
+           path contains ``/signup``.
+        2. ``toc.xhtml`` member whose text contains ``j-novel`` (case-insensitive)
+           AND matches ``Bonus\\s+((Color\\s+)?Illustrations?|(Short\\s+)?Stories)``
+           (case-insensitive).
+        3. ``copyright.xhtml`` member whose text contains ``premium``
+           (case-insensitive) AND matches ``Premium(\\s)+(E?-?Book|Epub)``
+           (case-insensitive).
+      Returns ``False`` on any exception (bad zip, decoding error, …).
+
+  get_subtitle_from_title(file, publisher=None)  [lru_cache(maxsize=3500)]
+      Takes a *Volume* object (NOT a string).  Extracts a subtitle from
+      ``file.name`` by requiring BOTH a dash/colon separator AND a year/Digital
+      marker (``(YYYY)`` or ``(Digital)``).  Returns ``""`` when:
+        * no dash/colon is found, or
+        * no year/Digital marker is found, or
+        * the extracted subtitle matches the parent-folder name, or
+        * the extracted subtitle looks like a volume keyword + number
+          (e.g. "Vol 1", "Volume 1").
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_vol(filename: str, root: str = "/tmp/nope"):
+    """Return a single Volume object built through the production pipeline."""
+    kce.get_subtitle_from_title.cache_clear()
+    files = kce.upgrade_to_file_class([filename], root, test_mode=True)
+    vols = kce.upgrade_to_volume_class(files, test_mode=True)
+    return vols[0]
+
+
+# ===========================================================================
+# contains_premium_content
+# ===========================================================================
+
+class TestContainsPremiumContent:
+    """Pin ``kce.contains_premium_content`` signals and negative cases.
+
+    The function reads the zip member-list string and selected member
+    contents to detect J-Novel Club / Tentacle Press premium epub signals.
+    All test archives are created in-memory via the ``cbz_factory`` fixture
+    (which writes to tmp_path).
+    """
+
+    # -----------------------------------------------------------------------
+    # Signal 1: bonus(.xhtml / _N.xhtml) file name AND /signup in member path
+    # -----------------------------------------------------------------------
+
+    def test_bonus_xhtml_numbered_and_signup_dir_returns_true(self, cbz_factory):
+        """A member named ``bonus_1.xhtml`` inside a ``/signup/`` path triggers
+        the first premium signal.
+
+        Observed: ``True``.
+        """
+        path = cbz_factory(
+            name="Premium v01.cbz",
+            entries={
+                "Text/bonus_1.xhtml": "<html>bonus</html>",
+                "Text/signup/index.html": "<html>signup</html>",
+            },
+        )
+        assert kce.contains_premium_content(str(path)) is True
+
+    def test_bonus_xhtml_unnumbered_and_signup_dir_returns_true(self, cbz_factory):
+        """A member named ``bonus.xhtml`` (no number) + ``/signup/`` path also
+        triggers signal 1 — the regex allows the digit group to be absent.
+
+        Observed: ``True``.
+        """
+        path = cbz_factory(
+            name="Premium v02.cbz",
+            entries={
+                "Text/bonus.xhtml": "<html>bonus</html>",
+                "Text/signup/index.html": "<html>signup</html>",
+            },
+        )
+        assert kce.contains_premium_content(str(path)) is True
+
+    def test_bonus_xhtml_without_signup_returns_false(self, cbz_factory):
+        """``bonus_1.xhtml`` present but no ``/signup`` path — signal 1 is
+        not triggered; no other signal exists.
+
+        Observed: ``False``.
+        """
+        path = cbz_factory(
+            name="NoPremium v01.cbz",
+            entries={
+                "Text/bonus_1.xhtml": "<html>bonus</html>",
+            },
+        )
+        assert kce.contains_premium_content(str(path)) is False
+
+    # -----------------------------------------------------------------------
+    # Signal 2: toc.xhtml with "j-novel" AND Bonus Illustrations/Stories
+    # -----------------------------------------------------------------------
+
+    def test_toc_jnovel_bonus_color_illustrations_returns_true(self, cbz_factory):
+        """``toc.xhtml`` containing both ``j-novel`` and
+        ``Bonus Color Illustrations`` triggers signal 2.
+
+        Observed: ``True``.
+        """
+        toc = (
+            "<html>J-Novel Club<br/>"
+            "<a href=\"bonus\">Bonus Color Illustrations</a></html>"
+        )
+        path = cbz_factory(
+            name="JNovel v01.cbz",
+            entries={"toc.xhtml": toc},
+        )
+        assert kce.contains_premium_content(str(path)) is True
+
+    def test_toc_jnovel_bonus_short_stories_returns_true(self, cbz_factory):
+        """``toc.xhtml`` with ``j-novel`` and ``Bonus Short Stories`` also
+        triggers signal 2.
+
+        Observed: ``True``.
+        """
+        toc = (
+            "<html>j-novel club<br/>"
+            "<a href=\"bonus\">Bonus Short Stories</a></html>"
+        )
+        path = cbz_factory(
+            name="JNovel v02.cbz",
+            entries={"toc.xhtml": toc},
+        )
+        assert kce.contains_premium_content(str(path)) is True
+
+    def test_toc_no_jnovel_bonus_illustrations_returns_false(self, cbz_factory):
+        """``toc.xhtml`` with ``Bonus Color Illustrations`` but no ``j-novel``
+        string does NOT trigger signal 2.
+
+        Observed: ``False``.
+        """
+        toc = (
+            "<html>Some Other Publisher<br/>"
+            "<a href=\"bonus\">Bonus Color Illustrations</a></html>"
+        )
+        path = cbz_factory(
+            name="NotJNovel v01.cbz",
+            entries={"toc.xhtml": toc},
+        )
+        assert kce.contains_premium_content(str(path)) is False
+
+    # -----------------------------------------------------------------------
+    # Signal 3: copyright.xhtml with "premium" AND "Premium E-Book/Epub"
+    # -----------------------------------------------------------------------
+
+    def test_copyright_premium_epub_returns_true(self, cbz_factory):
+        """``copyright.xhtml`` containing both ``premium`` and the phrase
+        ``Premium Epub`` triggers signal 3.
+
+        Observed: ``True``.
+        """
+        copyright_content = (
+            "<html>This is a Premium Epub edition by J-Novel Club</html>"
+        )
+        path = cbz_factory(
+            name="PremiumEpub v01.cbz",
+            entries={"copyright.xhtml": copyright_content},
+        )
+        assert kce.contains_premium_content(str(path)) is True
+
+    def test_copyright_premium_ebook_returns_true(self, cbz_factory):
+        """``copyright.xhtml`` with ``Premium E-Book`` phrase triggers signal 3.
+
+        Observed: ``True``.
+        """
+        copyright_content = "<html>This is a Premium E-Book edition</html>"
+        path = cbz_factory(
+            name="PremiumEBook v01.cbz",
+            entries={"copyright.xhtml": copyright_content},
+        )
+        assert kce.contains_premium_content(str(path)) is True
+
+    def test_copyright_no_premium_keyword_returns_false(self, cbz_factory):
+        """``copyright.xhtml`` without the word ``premium`` does not trigger
+        signal 3.
+
+        Observed: ``False``.
+        """
+        copyright_content = "<html>This is a Standard E-Book edition</html>"
+        path = cbz_factory(
+            name="StandardEBook v01.cbz",
+            entries={"copyright.xhtml": copyright_content},
+        )
+        assert kce.contains_premium_content(str(path)) is False
+
+    # -----------------------------------------------------------------------
+    # Negative / fallback cases
+    # -----------------------------------------------------------------------
+
+    def test_plain_image_archive_returns_false(self, cbz_factory):
+        """A standard CBZ with only a JPEG page has no premium signals.
+
+        Observed: ``False``.
+        """
+        path = cbz_factory(name="Regular v01.cbz")  # default: one real-JPEG page
+        assert kce.contains_premium_content(str(path)) is False
+
+    def test_non_zip_file_returns_false(self, tmp_path):
+        """An unreadable (non-zip) file triggers the except branch and returns
+        ``False``.
+
+        Observed: ``False``.
+        """
+        bad = tmp_path / "bad.cbz"
+        bad.write_bytes(b"not a zip file at all")
+        assert kce.contains_premium_content(str(bad)) is False
+
+
+# ===========================================================================
+# get_subtitle_from_title
+# ===========================================================================
+
+class TestGetSubtitleFromTitle:
+    """Pin ``kce.get_subtitle_from_title`` through the production Volume pipeline.
+
+    ``get_subtitle_from_title`` is called internally by ``upgrade_to_volume_class``
+    (unless ``skip_subtitle=True``) so the canonical way to exercise it is to
+    build a Volume via the pipeline and read ``vol.subtitle``.  Direct calls are
+    used for the cache-clear + re-invocation cases only.
+
+    The function requires BOTH:
+      * a dash (`` - ``) or colon (``: ``) separator in the filename, AND
+      * a year marker ``(YYYY)`` or a ``(Digital)`` marker.
+    If either is absent, it returns ``""``.
+    """
+
+    # -----------------------------------------------------------------------
+    # Basic subtitle extraction
+    # -----------------------------------------------------------------------
+
+    def test_dash_subtitle_with_year_and_digital(self):
+        """Standard ``Series vNN (YYYY) (Digital) - Subtitle.cbz`` extracts
+        the subtitle string after the last dash.
+
+        Observed: ``'A Subtitle'``.
+        """
+        vol = _build_vol("My Series v01 (2021) (Digital) - A Subtitle.cbz")
+        assert vol.subtitle == "A Subtitle"
+
+    def test_colon_subtitle_with_year_and_digital(self):
+        """A colon separator also works as the subtitle delimiter.
+
+        Observed: ``'Colon Subtitle'``.
+        """
+        vol = _build_vol("My Series v02 (2022) (Digital): Colon Subtitle.cbz")
+        assert vol.subtitle == "Colon Subtitle"
+
+    def test_dash_subtitle_with_year_only(self):
+        """Year marker alone (no ``(Digital)``) is sufficient to enable subtitle
+        extraction via the year_or_digital_search branch.
+
+        Observed: ``'Year Only Subtitle'``.
+        """
+        vol = _build_vol("My Series v01 (2021) - Year Only Subtitle.cbz")
+        assert vol.subtitle == "Year Only Subtitle"
+
+    def test_dash_subtitle_with_digital_only(self):
+        """``(Digital)`` marker alone (no year) is also sufficient.
+
+        Observed: ``'Digital Only Subtitle'``.
+        """
+        vol = _build_vol("My Series v01 (Digital) - Digital Only Subtitle.cbz")
+        assert vol.subtitle == "Digital Only Subtitle"
+
+    def test_extension_stripped_from_subtitle(self):
+        """If the raw subtitle ends with the file extension (e.g. ``.cbz``),
+        ``get_extensionless_name`` removes it.
+
+        Observed: ``'MySubtitle'`` (not ``'MySubtitle.cbz'``).
+        """
+        vol = _build_vol("My Series v01 (2021) (Digital) - MySubtitle.cbz")
+        assert vol.subtitle == "MySubtitle"
+
+    def test_epub_subtitle_extracted(self):
+        """Subtitle extraction works identically for ``.epub`` files.
+
+        Observed: ``'An Epub Subtitle'``.
+        """
+        vol = _build_vol(
+            "My Series v01 (2021) (Digital) - An Epub Subtitle.epub"
+        )
+        assert vol.subtitle == "An Epub Subtitle"
+
+    def test_multi_dash_takes_last_segment(self):
+        """When the filename contains multiple dash separators, the regex
+        ``(.*)((\\s+(-)|:)\\s+)`` greedily takes the rightmost one, yielding
+        only the last segment.
+
+        Observed: ``'Subtitle'`` (not ``'Multi - Word - Subtitle'``).
+        """
+        vol = _build_vol(
+            "My Series v01 (2021) (Digital) - Multi - Word - Subtitle.cbz"
+        )
+        assert vol.subtitle == "Subtitle"
+
+    # -----------------------------------------------------------------------
+    # No-subtitle cases (returns "")
+    # -----------------------------------------------------------------------
+
+    def test_no_dash_or_colon_returns_empty(self):
+        """A filename with no dash/colon separator returns ``""``.
+
+        Observed: ``''``.
+        """
+        vol = _build_vol("My Series v03 (2021).cbz")
+        assert vol.subtitle == ""
+
+    def test_dash_without_year_or_digital_returns_empty(self):
+        """Dash present but no year/Digital marker — no subtitle extracted.
+
+        Observed: ``''``.
+        """
+        vol = _build_vol("My Series v01 - No Year.cbz")
+        assert vol.subtitle == ""
+
+    def test_colon_without_year_returns_empty(self):
+        """Colon present but no year/Digital marker — no subtitle extracted.
+
+        Observed: ``''``.
+        """
+        vol = _build_vol("My Series v01: No Year.cbz")
+        assert vol.subtitle == ""
+
+    # -----------------------------------------------------------------------
+    # Suppression: subtitle matches folder name
+    # -----------------------------------------------------------------------
+
+    def test_subtitle_suppressed_when_it_matches_folder_name(self):
+        """If the extracted subtitle appears in ``os.path.basename(vol.path's
+        parent)`` (the series folder name), the function clears it to ``""``.
+
+        Root ``/tmp/My Series - A Subtitle`` → folder base is
+        ``My Series - A Subtitle`` which contains ``A Subtitle`` → suppressed.
+
+        Observed: ``''``.
+        """
+        vol = _build_vol(
+            "My Series v01 (2021) (Digital) - A Subtitle.cbz",
+            root="/tmp/My Series - A Subtitle",
+        )
+        assert vol.subtitle == ""
+
+    def test_subtitle_not_suppressed_when_folder_is_plain_series(self):
+        """When the folder name does NOT contain the subtitle, it is kept.
+
+        Root ``/tmp/My Series`` → folder base ``My Series`` does not contain
+        ``A Subtitle`` → subtitle preserved.
+
+        Observed: ``'A Subtitle'``.
+        """
+        vol = _build_vol(
+            "My Series v01 (2021) (Digital) - A Subtitle.cbz",
+            root="/tmp/My Series",
+        )
+        assert vol.subtitle == "A Subtitle"
+
+    # -----------------------------------------------------------------------
+    # Suppression: subtitle looks like a volume keyword + number
+    # -----------------------------------------------------------------------
+
+    def test_vol_1_subtitle_suppressed(self):
+        """A subtitle of ``'Vol 1'`` matches the volume-keyword regex and is
+        cleared to ``""``.
+
+        Observed: ``''``.
+        """
+        vol = _build_vol("MySeries v01 (2021) (Digital) - Vol 1.cbz")
+        assert vol.subtitle == ""
+
+    def test_volume_1_subtitle_suppressed(self):
+        """A subtitle of ``'Volume 1'`` similarly matches and is suppressed.
+
+        Observed: ``''``.
+        """
+        vol = _build_vol("My Series v01 (2021) (Digital) - Volume 1.cbz")
+        assert vol.subtitle == ""
+
+    # -----------------------------------------------------------------------
+    # Legitimate subtitles that look like chapter/prologue content
+    # -----------------------------------------------------------------------
+
+    def test_chapter_2_subtitle_not_suppressed(self):
+        """A subtitle ``'Chapter 2'`` is NOT a volume keyword match; it is
+        preserved as-is.
+
+        Observed: ``'Chapter 2'``.
+
+        # FLAG: 'Chapter 2' is an odd subtitle for a volume file, but the code
+        # returns it unchanged — characterization pins this as-is.
+        """
+        vol = _build_vol("MySeries v02 (2021) (Digital) - Chapter 2.cbz")
+        assert vol.subtitle == "Chapter 2"
+
+    def test_prologue_subtitle_not_suppressed(self):
+        """A subtitle of ``'Prologue'`` is kept because it does not match the
+        volume-keyword regex.
+
+        Observed: ``'Prologue'``.
+        """
+        vol = _build_vol("MySeries v03 (2021) (Digital) - Prologue.cbz")
+        assert vol.subtitle == "Prologue"
+
+    # -----------------------------------------------------------------------
+    # Direct call to get_subtitle_from_title — confirming it takes a Volume
+    # -----------------------------------------------------------------------
+
+    def test_direct_call_matches_pipeline_output(self):
+        """Calling ``kce.get_subtitle_from_title(vol, publisher=vol.publisher)``
+        directly after clearing the cache returns the same value as the
+        pipeline sets on ``vol.subtitle``.
+
+        Observed: ``'A Subtitle'``.
+        """
+        vol = _build_vol(
+            "My Series v01 (2021) (Digital) - A Subtitle.cbz",
+            root="/tmp/nope",
+        )
+        # Pipeline already called it; clear cache and call again manually.
+        kce.get_subtitle_from_title.cache_clear()
+        result = kce.get_subtitle_from_title(vol, publisher=vol.publisher)
+        assert result == "A Subtitle"
+
+    def test_direct_call_no_subtitle_returns_empty_string(self):
+        """Direct call on a no-subtitle volume returns ``""`` (not ``None``).
+
+        Observed: ``''``.
+        """
+        vol = _build_vol("My Series v03 (2021).cbz")
+        kce.get_subtitle_from_title.cache_clear()
+        result = kce.get_subtitle_from_title(vol, publisher=vol.publisher)
+        assert result == ""
+        assert isinstance(result, str)

--- a/tests/engine/test_scoring.py
+++ b/tests/engine/test_scoring.py
@@ -1,0 +1,437 @@
+"""Characterization tests for the keyword scoring and upgrade decision engine.
+
+Pins the CURRENT behaviour of:
+  * get_keyword_scores(releases) -> list[RankedKeywordResult]
+  * is_upgradeable(downloaded, current) -> UpgradeResult
+  * get_highest_release(releases, is_chapter_directory) -> int | float | str
+
+All golden values were observed by running snippets against the project .venv
+on the tests/upgrade-scoring-engine branch BEFORE writing the assertions —
+no value was guessed.
+
+Key environment facts:
+  * ranked_keywords defaults to [] and compiled_searches defaults to []
+    (both are set in settings.py / komga_cover_extractor.py module-level).
+  * test_mode=True in upgrade_to_volume_class skips release_year, publisher, and
+    premium_content lookups (so volume_year=None, is_premium=False, release_group='').
+  * The autouse isolated_globals fixture from conftest.py restores kce module globals
+    (including ranked_keywords and compiled_searches) after every test.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+import komga_cover_extractor as kce
+from settings import Keyword
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_vols(*filenames: str, root: str = "/tmp/nope"):
+    """Return list[Volume] through the production pipeline with test_mode=True."""
+    files = kce.upgrade_to_file_class(list(filenames), root, test_mode=True)
+    assert files
+    return kce.upgrade_to_volume_class(files, test_mode=True)
+
+
+def _set_keywords(*keywords: Keyword):
+    """Replace kce.ranked_keywords and rebuild kce.compiled_searches."""
+    kce.ranked_keywords = list(keywords)
+    kce.compiled_searches = [
+        re.compile(kw.name, re.IGNORECASE) for kw in kce.ranked_keywords
+    ]
+
+
+# ===========================================================================
+# get_keyword_scores — default empty ranked_keywords
+# ===========================================================================
+
+class TestGetKeywordScoresDefaultEmpty:
+    """With default empty ranked_keywords, scores must be 0.0 and tags empty."""
+
+    def test_returns_list(self):
+        vols = _build_vols("Some Name v01 (2021) (Digital) [Group].cbz")
+        results = kce.get_keyword_scores(vols)
+        assert isinstance(results, list)
+
+    def test_length_matches_input(self):
+        vols = _build_vols("Some Name v01 (2021) (Digital) [Group].cbz")
+        results = kce.get_keyword_scores(vols)
+        assert len(results) == 1
+
+    def test_result_type_is_RankedKeywordResult(self):
+        vols = _build_vols("Some Name v01 (2021) (Digital) [Group].cbz")
+        result = kce.get_keyword_scores(vols)[0]
+        assert isinstance(result, kce.RankedKeywordResult)
+
+    def test_total_score_is_zero_float(self):
+        vols = _build_vols("Some Name v01 (2021) (Digital) [Group].cbz")
+        result = kce.get_keyword_scores(vols)[0]
+        # Empty ranked_keywords → score starts and stays at 0.0 (float)
+        assert result.total_score == 0.0
+        assert isinstance(result.total_score, float)
+
+    def test_keywords_list_is_empty(self):
+        vols = _build_vols("Some Name v01 (2021) (Digital) [Group].cbz")
+        result = kce.get_keyword_scores(vols)[0]
+        assert result.keywords == []
+        assert isinstance(result.keywords, list)
+
+    def test_empty_releases_list_returns_empty(self):
+        results = kce.get_keyword_scores([])
+        assert results == []
+        assert isinstance(results, list)
+
+
+# ===========================================================================
+# get_keyword_scores — with a known ranked_keywords configuration
+# ===========================================================================
+
+class TestGetKeywordScoresNonTrivial:
+    """Exercise non-zero scoring by setting a small known kce.ranked_keywords."""
+
+    def setup_method(self):
+        # Observed: Digital=10, [Group] regex=3 → total 13.0 for the test filename.
+        # isolated_globals autouse fixture restores these after the test.
+        _set_keywords(
+            Keyword(r"Digital", 10.0, "both"),
+            Keyword(r"Webrip", 3.0, "both"),
+            Keyword(r"\[Group\]", 3.0, "both"),
+        )
+
+    def test_matching_keyword_adds_score(self):
+        vols = _build_vols("Some Name v01 (2021) (Digital) [Group].cbz")
+        result = kce.get_keyword_scores(vols)[0]
+        # Digital (10) + [Group] (3) match; Webrip does not.
+        assert result.total_score == 13.0
+        assert isinstance(result.total_score, float)
+
+    def test_matched_keywords_list_length(self):
+        vols = _build_vols("Some Name v01 (2021) (Digital) [Group].cbz")
+        result = kce.get_keyword_scores(vols)[0]
+        assert len(result.keywords) == 2
+
+    def test_matched_keyword_names_are_search_group_not_pattern(self):
+        # search.group() is stored, not keyword.name — so case of the actual
+        # matched text is preserved (e.g. lowercase "digital" if file is lowercase).
+        _set_keywords(Keyword(r"DIGITAL", 10.0, "both"))
+        vols = _build_vols("Some Name v01 (digital).cbz")
+        result = kce.get_keyword_scores(vols)[0]
+        assert result.keywords[0].name == "digital"  # actual match text
+
+    def test_matched_keyword_score_value(self):
+        vols = _build_vols("Some Name v01 (2021) (Digital) [Group].cbz")
+        result = kce.get_keyword_scores(vols)[0]
+        scores = {kw.name: kw.score for kw in result.keywords}
+        assert scores["Digital"] == 10.0
+        assert scores["[Group]"] == 3.0
+
+    def test_matched_keyword_default_file_type_both(self):
+        # Keyword objects appended to .keywords are constructed as
+        # Keyword(search.group(), keyword.score) — 2-arg form → file_type='both'.
+        vols = _build_vols("Some Name v01 (2021) (Digital) [Group].cbz")
+        result = kce.get_keyword_scores(vols)[0]
+        for kw in result.keywords:
+            assert kw.file_type == "both"
+
+    def test_non_matching_keyword_contributes_zero(self):
+        _set_keywords(Keyword(r"Nonexistent", 10.0, "both"))
+        vols = _build_vols("Some Name v01 (2021) (Digital) [Group].cbz")
+        result = kce.get_keyword_scores(vols)[0]
+        assert result.total_score == 0.0
+        assert result.keywords == []
+
+    def test_multiple_releases_scored_independently(self):
+        vols = _build_vols(
+            "Some Name v01 (2021) (Digital).cbz",
+            "Some Name v01 (2021) (Webrip).cbz",
+        )
+        results = kce.get_keyword_scores(vols)
+        assert len(results) == 2
+        # Digital matches first, Webrip matches second
+        assert results[0].total_score == 10.0
+        assert results[1].total_score == 3.0
+        assert results[0] is not results[1]
+
+    def test_file_type_volume_only_keyword_skipped_for_chapter(self):
+        # A keyword with file_type='volume' must NOT be applied to chapter files.
+        _set_keywords(
+            Keyword(r"Digital", 10.0, "both"),
+            Keyword(r"Premium", 5.0, "volume"),
+        )
+        ch_vols = _build_vols("Some Name Chapter 001 (Digital) (Premium).cbz")
+        assert ch_vols[0].file_type == "chapter"
+        result = kce.get_keyword_scores(ch_vols)[0]
+        # Only the 'both' keyword should match
+        assert result.total_score == 10.0
+        assert len(result.keywords) == 1
+        assert result.keywords[0].name == "Digital"
+
+    def test_file_type_chapter_only_keyword_skipped_for_volume(self):
+        # A keyword with file_type='chapter' must NOT be applied to volume files.
+        _set_keywords(
+            Keyword(r"Premium", 5.0, "volume"),
+            Keyword(r"Digital", 10.0, "chapter"),
+        )
+        vol_vols = _build_vols("Some Name v01 (Digital) (Premium).cbz")
+        assert vol_vols[0].file_type == "volume"
+        result = kce.get_keyword_scores(vol_vols)[0]
+        # Only 'volume' keyword applies
+        assert result.total_score == 5.0
+        assert len(result.keywords) == 1
+        assert result.keywords[0].name == "Premium"
+
+    def test_file_type_both_applies_to_volume(self):
+        _set_keywords(Keyword(r"Digital", 10.0, "both"))
+        vol_vols = _build_vols("Some Name v01 (Digital).cbz")
+        assert vol_vols[0].file_type == "volume"
+        result = kce.get_keyword_scores(vol_vols)[0]
+        assert result.total_score == 10.0
+
+    def test_file_type_both_applies_to_chapter(self):
+        _set_keywords(Keyword(r"Digital", 10.0, "both"))
+        ch_vols = _build_vols("Some Name Chapter 001 (Digital).cbz")
+        assert ch_vols[0].file_type == "chapter"
+        result = kce.get_keyword_scores(ch_vols)[0]
+        assert result.total_score == 10.0
+
+
+# ===========================================================================
+# is_upgradeable — FLAG: identical names share results[0]
+# ===========================================================================
+
+class TestIsUpgradeableSameName:
+    """
+    FLAG: when downloaded_release.name == current_release.name, the code calls
+    get_keyword_scores([downloaded_release]) and assigns results[0] to BOTH
+    downloaded_release_result and current_release_result.
+
+    Consequence: even if the single file theoretically "scores higher than itself",
+    the comparison is always False (score > score is False) and the two result
+    objects are literally the same Python object.
+    """
+
+    def setup_method(self):
+        _set_keywords(Keyword(r"Digital", 10.0, "both"))
+
+    def test_same_file_object_never_upgradeable(self):
+        vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        vol = vols[0]
+        result = kce.is_upgradeable(vol, vol)
+        assert result.is_upgrade is False
+
+    def test_same_name_different_instances_never_upgradeable(self):
+        # Two distinct Volume objects but identical .name strings
+        vols1 = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        vols2 = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        dl, curr = vols1[0], vols2[0]
+        assert dl is not curr          # different objects
+        assert dl.name == curr.name    # but identical names
+        result = kce.is_upgradeable(dl, curr)
+        # FLAG: identical names → only 1 call to get_keyword_scores → results[0] shared
+        assert result.is_upgrade is False
+
+    def test_same_name_result_objects_are_identical(self):
+        """The FLAG: downloaded_ranked_result IS current_ranked_result (same object)."""
+        vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        result = kce.is_upgradeable(vols[0], vols[0])
+        # Both fields point to the same RankedKeywordResult object
+        assert result.downloaded_ranked_result is result.current_ranked_result
+
+    def test_same_name_scores_both_equal(self):
+        vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        result = kce.is_upgradeable(vols[0], vols[0])
+        dl_score = result.downloaded_ranked_result.total_score
+        curr_score = result.current_ranked_result.total_score
+        assert dl_score == curr_score
+        assert dl_score == 10.0
+
+
+# ===========================================================================
+# is_upgradeable — different names
+# ===========================================================================
+
+class TestIsUpgradeableDifferentNames:
+    """When names differ, get_keyword_scores is called with both releases."""
+
+    def setup_method(self):
+        _set_keywords(
+            Keyword(r"Digital", 10.0, "both"),
+            Keyword(r"Webrip", 3.0, "both"),
+        )
+
+    def test_higher_score_downloaded_is_upgrade(self):
+        dl_vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        curr_vols = _build_vols("Some Name v01 (2021) (Webrip).cbz")
+        result = kce.is_upgradeable(dl_vols[0], curr_vols[0])
+        assert result.is_upgrade is True
+        assert result.downloaded_ranked_result.total_score == 10.0
+        assert result.current_ranked_result.total_score == 3.0
+
+    def test_lower_score_downloaded_is_not_upgrade(self):
+        dl_vols = _build_vols("Some Name v01 (2021) (Webrip).cbz")
+        curr_vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        result = kce.is_upgradeable(dl_vols[0], curr_vols[0])
+        assert result.is_upgrade is False
+        assert result.downloaded_ranked_result.total_score == 3.0
+        assert result.current_ranked_result.total_score == 10.0
+
+    def test_equal_scores_different_names_is_not_upgrade(self):
+        # Both score 10.0 — equal is NOT an upgrade (strict >)
+        _set_keywords(
+            Keyword(r"Digital", 10.0, "both"),
+            Keyword(r"Webrip", 10.0, "both"),
+        )
+        dl_vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        curr_vols = _build_vols("Some Name v01 (2021) (Webrip).cbz")
+        result = kce.is_upgradeable(dl_vols[0], curr_vols[0])
+        assert result.is_upgrade is False
+
+    def test_result_objects_are_different_when_names_differ(self):
+        dl_vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        curr_vols = _build_vols("Some Name v01 (2021) (Webrip).cbz")
+        result = kce.is_upgradeable(dl_vols[0], curr_vols[0])
+        assert result.downloaded_ranked_result is not result.current_ranked_result
+
+    def test_return_type_is_UpgradeResult(self):
+        dl_vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        curr_vols = _build_vols("Some Name v01 (2021) (Webrip).cbz")
+        result = kce.is_upgradeable(dl_vols[0], curr_vols[0])
+        assert isinstance(result, kce.UpgradeResult)
+        assert isinstance(result.is_upgrade, bool)
+        assert isinstance(result.downloaded_ranked_result, kce.RankedKeywordResult)
+        assert isinstance(result.current_ranked_result, kce.RankedKeywordResult)
+
+    def test_downloaded_keywords_list_correct(self):
+        dl_vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        curr_vols = _build_vols("Some Name v01 (2021) (Webrip).cbz")
+        result = kce.is_upgradeable(dl_vols[0], curr_vols[0])
+        dl_kw_names = [kw.name for kw in result.downloaded_ranked_result.keywords]
+        curr_kw_names = [kw.name for kw in result.current_ranked_result.keywords]
+        assert "Digital" in dl_kw_names
+        assert "Webrip" in curr_kw_names
+
+    def test_zero_vs_nonzero_is_upgrade(self):
+        # Downloaded file matches nothing (score 0) vs current matches Digital (score 10)
+        dl_vols = _build_vols("Some Name v01 (2021).cbz")
+        curr_vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        result = kce.is_upgradeable(dl_vols[0], curr_vols[0])
+        assert result.is_upgrade is False
+        assert result.downloaded_ranked_result.total_score == 0.0
+        assert result.current_ranked_result.total_score == 10.0
+
+    def test_nonzero_vs_zero_is_upgrade(self):
+        # Downloaded matches Digital (10), current matches nothing (0) → upgrade
+        dl_vols = _build_vols("Some Name v01 (2021) (Digital).cbz")
+        curr_vols = _build_vols("Some Name v01 (2021).cbz")
+        result = kce.is_upgradeable(dl_vols[0], curr_vols[0])
+        assert result.is_upgrade is True
+        assert result.downloaded_ranked_result.total_score == 10.0
+        assert result.current_ranked_result.total_score == 0.0
+
+
+# ===========================================================================
+# get_highest_release
+# ===========================================================================
+
+class TestGetHighestRelease:
+    """Pin get_highest_release behaviour under various conditions.
+
+    The function is gated on kce.use_latest_volume_cover_as_series_cover
+    (defaults False → always returns '').  When True, it finds the max
+    numeric index from a tuple of releases.
+    """
+
+    def test_toggle_off_returns_empty_string_regardless_of_input(self):
+        # Default: use_latest_volume_cover_as_series_cover = False
+        assert kce.use_latest_volume_cover_as_series_cover is False
+        result = kce.get_highest_release((1, 2, 3), is_chapter_directory=False)
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_toggle_off_chapter_directory_returns_empty_string(self):
+        result = kce.get_highest_release((1, 2, 3), is_chapter_directory=True)
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_toggle_on_simple_ints_returns_max(self):
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        result = kce.get_highest_release((1, 2, 3), is_chapter_directory=False)
+        assert result == 3
+        assert isinstance(result, int)
+
+    def test_toggle_on_chapter_directory_returns_empty_string(self):
+        # is_chapter_directory=True bypasses the volume logic → always ''
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        result = kce.get_highest_release((1, 2, 3), is_chapter_directory=True)
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_toggle_on_floats_returns_max_float(self):
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        result = kce.get_highest_release((1.5, 2.0, 0.5), is_chapter_directory=False)
+        assert result == 2.0
+        assert isinstance(result, float)
+
+    def test_toggle_on_with_empty_string_items_skips_them(self):
+        # '' items are skipped; max of remaining numeric values returned
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        result = kce.get_highest_release((1, "", 3), is_chapter_directory=False)
+        assert result == 3
+        assert isinstance(result, int)
+
+    def test_toggle_on_all_empty_or_none_returns_empty_string(self):
+        # All items are '' or None → highest_num stays '' (initial value)
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        result = kce.get_highest_release(("", "", None), is_chapter_directory=False)
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_toggle_on_tuple_items_max_of_each_tuple(self):
+        # Tuple items (multi-volume) → use max() of each tuple item
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        result = kce.get_highest_release(((1, 2), (3, 4)), is_chapter_directory=False)
+        assert result == 4
+        assert isinstance(result, int)
+
+    def test_toggle_on_mixed_int_and_tuple_items(self):
+        # contains_empty_or_tuple_index_number is True → uses the scanning loop
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        result = kce.get_highest_release(((1, 3), 5), is_chapter_directory=False)
+        assert result == 5
+        assert isinstance(result, int)
+
+    def test_toggle_on_empty_tuple_raises_ValueError(self):
+        """FLAG: max() on empty tuple raises ValueError — no guard exists."""
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        with pytest.raises(ValueError, match="max\\(\\) iterable argument is empty"):
+            kce.get_highest_release((), is_chapter_directory=False)
+
+    def test_is_lru_cached(self):
+        assert hasattr(kce.get_highest_release, "cache_clear")
+        assert hasattr(kce.get_highest_release, "cache_info")
+
+    def test_lru_cache_maxsize_is_3500(self):
+        info = kce.get_highest_release.cache_info()
+        assert info.maxsize == 3500
+
+    def test_lru_cache_hit_on_repeated_call(self):
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        kce.get_highest_release((1, 2, 3), is_chapter_directory=False)
+        kce.get_highest_release((1, 2, 3), is_chapter_directory=False)
+        info = kce.get_highest_release.cache_info()
+        assert info.hits >= 1

--- a/tests/engine/test_series_matching.py
+++ b/tests/engine/test_series_matching.py
@@ -1,0 +1,696 @@
+"""Characterization tests for the series-matching cluster.
+
+Functions covered:
+  - parse_words              (kce.py ~line 6065)
+  - find_consecutive_items   (kce.py ~line 6085)
+  - get_series_name_from_contents  (kce.py ~line 2240)
+  - get_identifiers          (kce.py ~line 6051)
+  - get_shortened_title      (kce.py ~line 9726)
+  - upgrade_to_file_class + upgrade_to_volume_class golden snapshots
+
+All assertion values were FIRST observed by running the production module under
+.venv/bin/python3 on the tests/upgrade-scoring-engine branch (after commit 300cfb4)
+and then pinned as-is.  FLAG: comments document surprising / buggy behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_volumes(file_names, root="/tmp/nope"):
+    """Pipeline helper: upgrade_to_file_class -> upgrade_to_volume_class (test_mode)."""
+    files = kce.upgrade_to_file_class(file_names, root, test_mode=True)
+    return kce.upgrade_to_volume_class(files, test_mode=True)
+
+
+# ===========================================================================
+# parse_words
+# ===========================================================================
+
+class TestParseWords:
+    """Characterize parse_words — incl. the dead-unidecode FLAG."""
+
+    # -----------------------------------------------------------------------
+    # Return type
+    # -----------------------------------------------------------------------
+
+    def test_returns_list(self):
+        result = kce.parse_words("Hello World")
+        assert isinstance(result, list)
+
+    # -----------------------------------------------------------------------
+    # Basic behaviour
+    # -----------------------------------------------------------------------
+
+    def test_simple_ascii_title(self):
+        assert kce.parse_words("Some Name v01 (2021)") == ["some", "name", "v01", "2021"]
+
+    def test_empty_string_returns_empty_list(self):
+        assert kce.parse_words("") == []
+
+    def test_none_returns_empty_list(self):
+        # FLAG: None is passed as user_string; the ``if user_string:`` guard
+        # short-circuits and returns [] rather than raising TypeError.
+        assert kce.parse_words(None) == []
+
+    def test_punctuation_stripped(self):
+        assert kce.parse_words("Hello, World!") == ["hello", "world"]
+
+    def test_colon_stripped(self):
+        assert kce.parse_words("Naruto: Uzumaki Chronicles") == [
+            "naruto",
+            "uzumaki",
+            "chronicles",
+        ]
+
+    def test_hyphen_stripped_joins_words(self):
+        # Hyphens are punctuation; 'One-Punch' loses the dash → 'onepunch'.
+        assert kce.parse_words("One-Punch Man") == ["onepunch", "man"]
+
+    def test_period_stripped(self):
+        assert kce.parse_words("vol.01") == ["vol01"]
+
+    def test_lowercase_conversion(self):
+        assert kce.parse_words("Attack on Titan") == ["attack", "on", "titan"]
+
+    # -----------------------------------------------------------------------
+    # FLAG: dead unidecode — unicode characters ARE preserved in output
+    # -----------------------------------------------------------------------
+
+    def test_accented_char_preserved_not_ascii_folded(self):
+        # FLAG: parse_words computes ``words_no_uni = unidecode(words_lower)``
+        # but then splits ``words_lower`` (not ``words_no_uni``), so unidecode
+        # is dead code.  The returned list keeps the original accented form.
+        # If the bug were ever fixed, the result would be ['cafe'] not ['café'].
+        result = kce.parse_words("Café au lait")
+        assert result == ["café", "au", "lait"]
+
+    def test_accented_naïve_résumé_preserved(self):
+        # FLAG: same dead-unidecode issue — accents survive.
+        result = kce.parse_words("Naïve résumé")
+        assert result == ["naïve", "résumé"]
+
+    def test_german_umlaut_preserved(self):
+        # FLAG: 'über' is not transliterated to 'uber'.
+        result = kce.parse_words("Über Doctor Strange")
+        assert result == ["über", "doctor", "strange"]
+
+    def test_cjk_characters_preserved_not_transliterated(self):
+        # FLAG: unidecode would turn '東京' → 'Dong Jing', but the split is on
+        # words_lower so the CJK token survives as-is.
+        result = kce.parse_words("東京 Ghoul v01")
+        assert result == ["東京", "ghoul", "v01"]
+
+
+# ===========================================================================
+# find_consecutive_items
+# ===========================================================================
+
+class TestFindConsecutiveItems:
+    """Characterize find_consecutive_items — position-based, not value-based."""
+
+    # -----------------------------------------------------------------------
+    # Return type
+    # -----------------------------------------------------------------------
+
+    def test_returns_bool_true(self):
+        result = kce.find_consecutive_items((1, 2, 3), (1, 2, 3))
+        assert isinstance(result, bool)
+        assert result is True
+
+    def test_returns_bool_false(self):
+        result = kce.find_consecutive_items((1, 2, 3), (4, 5, 6))
+        assert isinstance(result, bool)
+        assert result is False
+
+    # -----------------------------------------------------------------------
+    # Insufficient length short-circuit
+    # -----------------------------------------------------------------------
+
+    def test_arr1_shorter_than_count_returns_false(self):
+        # len(arr1) < count → immediate False, no element comparison.
+        assert kce.find_consecutive_items((1, 2), (1, 2, 3), count=3) is False
+
+    def test_arr2_shorter_than_count_returns_false(self):
+        assert kce.find_consecutive_items((1, 2, 3), (1, 2), count=3) is False
+
+    def test_both_shorter_than_count_returns_false(self):
+        assert kce.find_consecutive_items((1, 2), (1, 2), count=3) is False
+
+    def test_empty_arrays_return_false(self):
+        assert kce.find_consecutive_items((), (), count=3) is False
+
+    # -----------------------------------------------------------------------
+    # Exact matches
+    # -----------------------------------------------------------------------
+
+    def test_identical_arrays_returns_true(self):
+        arr = (1, 2, 3, 4)
+        assert kce.find_consecutive_items(arr, arr) is True
+
+    def test_matching_prefix_returns_true(self):
+        assert kce.find_consecutive_items((1, 2, 3, 4, 5), (0, 1, 2, 3)) is True
+
+    def test_matching_subsequence_in_middle_returns_true(self):
+        assert kce.find_consecutive_items((10, 20, 1, 2, 3), (1, 2, 3, 30, 40)) is True
+
+    def test_no_shared_subsequence_returns_false(self):
+        assert kce.find_consecutive_items((1, 2, 3), (4, 5, 6)) is False
+
+    # -----------------------------------------------------------------------
+    # Custom count parameter
+    # -----------------------------------------------------------------------
+
+    def test_count_2_match_returns_true(self):
+        assert kce.find_consecutive_items((1, 2, 5), (1, 2, 7), count=2) is True
+
+    def test_count_1_same_element_returns_true(self):
+        assert kce.find_consecutive_items((7,), (7,), count=1) is True
+
+    def test_count_1_different_element_returns_false(self):
+        assert kce.find_consecutive_items((1,), (2,), count=1) is False
+
+    # -----------------------------------------------------------------------
+    # NOTE: comparison is positional, not numerical-gap — (1,5,9) vs (1,5,9)
+    # returns True even though values are not numerically consecutive.
+    # -----------------------------------------------------------------------
+
+    def test_positionally_consecutive_non_sequential_values(self):
+        # (1,5,9) and (1,5,9,13): the 3-element run [1,5,9] appears at position 0
+        # in both arrays, so this returns True.  "consecutive" means adjacent
+        # positions in the array, NOT consecutive integer values.
+        a = (1, 5, 9)
+        b = (1, 5, 9, 13)
+        assert kce.find_consecutive_items(a, b, count=3) is True
+
+    def test_match_at_tail_of_first_array(self):
+        # (8,9) appears at positions [8,9] in range(10) and at positions [0,1] in b.
+        a = tuple(range(10))
+        b = (8, 9, 99, 100)
+        assert kce.find_consecutive_items(a, b, count=2) is True
+
+    def test_word_tuple_prefix_match(self):
+        w1 = ("attack", "on", "titan", "before", "the", "fall")
+        w2 = ("attack", "on", "titan")
+        assert kce.find_consecutive_items(w1, w2, count=3) is True
+
+    def test_word_tuple_prefix_match_reversed_args(self):
+        w1 = ("attack", "on", "titan", "before", "the", "fall")
+        w2 = ("attack", "on", "titan")
+        assert kce.find_consecutive_items(w2, w1, count=3) is True
+
+    def test_word_tuple_no_match(self):
+        w1 = ("my", "hero", "academia")
+        w2 = ("one", "punch", "man")
+        assert kce.find_consecutive_items(w1, w2, count=3) is False
+
+    def test_three_word_match_in_four_word_arrays(self):
+        w1 = ("the", "quick", "brown", "fox")
+        w2 = ("a", "quick", "brown", "fox", "jumped")
+        assert kce.find_consecutive_items(w1, w2, count=3) is True
+
+
+# ===========================================================================
+# get_series_name_from_contents
+# ===========================================================================
+
+class TestGetSeriesNameFromContents:
+    """Characterize get_series_name_from_contents — char-by-char folder scan."""
+
+    # -----------------------------------------------------------------------
+    # Return type
+    # -----------------------------------------------------------------------
+
+    def test_returns_str(self):
+        result = kce.get_series_name_from_contents("Naruto", ["Naruto v01.cbz"])
+        assert isinstance(result, str)
+
+    # -----------------------------------------------------------------------
+    # Empty / degenerate inputs
+    # -----------------------------------------------------------------------
+
+    def test_empty_file_list_returns_empty_string(self):
+        assert kce.get_series_name_from_contents("Naruto", []) == ""
+
+    def test_series_shorter_than_3_chars_returns_empty(self):
+        # Minimum match length is 3 characters.
+        assert kce.get_series_name_from_contents("AB", ["AB v01.cbz", "AB v02.cbz"]) == ""
+
+    def test_exactly_3_char_series_name_returned(self):
+        assert kce.get_series_name_from_contents("ABC", ["ABC v01.cbz", "ABC v02.cbz"]) == "ABC"
+
+    # -----------------------------------------------------------------------
+    # 100 % required_matching_percent (default)
+    # -----------------------------------------------------------------------
+
+    def test_all_files_match_full_folder_name(self):
+        assert kce.get_series_name_from_contents(
+            "Naruto", ["Naruto v01.cbz", "Naruto v02.cbz"]
+        ) == "Naruto"
+
+    def test_all_files_match_multiword_name(self):
+        assert kce.get_series_name_from_contents(
+            "Dragonball Z", ["Dragonball Z v01.cbz", "Dragonball Z v02.cbz"]
+        ) == "Dragonball Z"
+
+    def test_mismatch_at_second_file_100pct_stops_early(self):
+        # "My Hero Academia" vs "My Neighbor Totoro" diverge at char index 3 ('H' vs 'N').
+        # With 100 % required, any mismatch terminates the scan.  The result is 'My'
+        # (2 chars) which is below the 3-char minimum → returns "".
+        # Verified: actual result is 'My', stripped to 'My', < 3 chars → "".
+        # NOTE: the match stops at the first diverging char; strip() is applied at end.
+        result = kce.get_series_name_from_contents(
+            "My Hero Academia",
+            ["My Hero Academia v01.cbz", "My Neighbor Totoro.cbz"],
+        )
+        assert result == "My"
+
+    def test_single_file_fully_matching_returns_series(self):
+        assert kce.get_series_name_from_contents("Berserk", ["Berserk v01.cbz"]) == "Berserk"
+
+    def test_folder_longer_than_file_stops_at_file_end(self):
+        # File 'Some.cbz' is shorter than folder 'Some Long Folder Name'.
+        # Scan stops when i >= len(file_name): matching_count becomes 0, loop breaks.
+        assert kce.get_series_name_from_contents(
+            "Some Long Folder Name", ["Some.cbz"]
+        ) == "Some"
+
+    def test_folder_longer_than_file_2(self):
+        # 'Dragon Ball.cbz' is shorter than 'Dragon Ball Super'.
+        assert kce.get_series_name_from_contents(
+            "Dragon Ball Super", ["Dragon Ball.cbz"]
+        ) == "Dragon Ball"
+
+    # -----------------------------------------------------------------------
+    # Case-insensitive comparison (char.lower() == file_char.lower())
+    # -----------------------------------------------------------------------
+
+    def test_case_insensitive_comparison(self):
+        # Folder is lowercase 'naruto', files start with uppercase 'N' —
+        # the comparison is case-insensitive so the folder chars are returned verbatim.
+        result = kce.get_series_name_from_contents(
+            "naruto", ["Naruto v01.cbz", "Naruto v02.cbz"]
+        )
+        assert result == "naruto"
+
+    # -----------------------------------------------------------------------
+    # Trailing whitespace stripping
+    # -----------------------------------------------------------------------
+
+    def test_trailing_spaces_stripped_from_result(self):
+        # Folder 'My Manga  ' has trailing spaces.  strip() is called on the result.
+        result = kce.get_series_name_from_contents(
+            "My Manga  ", ["My Manga v01.cbz", "My Manga v02.cbz"]
+        )
+        assert result == "My Manga"
+
+    # -----------------------------------------------------------------------
+    # Non-100 % required_matching_percent
+    # -----------------------------------------------------------------------
+
+    def test_50pct_matching_allows_partial_mismatch(self):
+        # With 50 %, 1 of 2 files matching at each position is enough.
+        result = kce.get_series_name_from_contents(
+            "My Hero Academia",
+            ["My Hero Academia v01.cbz", "My Neighbor Totoro.cbz"],
+            required_matching_percent=50,
+        )
+        assert result == "My Hero Academia"
+
+
+# ===========================================================================
+# get_identifiers
+# ===========================================================================
+
+class TestGetIdentifiers:
+    """Characterize get_identifiers — case-sensitivity FLAG."""
+
+    # -----------------------------------------------------------------------
+    # Return type
+    # -----------------------------------------------------------------------
+
+    def test_returns_list(self):
+        assert isinstance(kce.get_identifiers("Identifiers: foo:bar"), list)
+
+    # -----------------------------------------------------------------------
+    # Normal (title-case) happy paths
+    # -----------------------------------------------------------------------
+
+    def test_single_identifier(self):
+        assert kce.get_identifiers("Identifiers: anilist:12345") == ["anilist:12345"]
+
+    def test_two_identifiers(self):
+        result = kce.get_identifiers("Identifiers: isbn:9781234567890, comicid:12345")
+        assert result == ["isbn:9781234567890", "comicid:12345"]
+
+    def test_three_identifiers(self):
+        comment = "Title: Something\nIdentifiers: isbn:111, comicid:222, anilist:333"
+        assert kce.get_identifiers(comment) == ["isbn:111", "comicid:222", "anilist:333"]
+
+    def test_realistic_zip_comment(self):
+        comment = "Title: Naruto\nVolume: 1\nIdentifiers: isbn:9781421500614, comicid:56789"
+        assert kce.get_identifiers(comment) == ["isbn:9781421500614", "comicid:56789"]
+
+    def test_whitespace_trimmed_from_each_identifier(self):
+        # strip() is applied per-identifier.
+        result = kce.get_identifiers("Identifiers:  isbn:111 , comicid:222 ")
+        assert result == ["isbn:111", "comicid:222"]
+
+    # -----------------------------------------------------------------------
+    # Empty / no-match inputs
+    # -----------------------------------------------------------------------
+
+    def test_no_identifiers_keyword_returns_empty_list(self):
+        assert kce.get_identifiers("Some random comment") == []
+
+    def test_empty_string_returns_empty_list(self):
+        assert kce.get_identifiers("") == []
+
+    # -----------------------------------------------------------------------
+    # FLAG: case-sensitivity bug
+    # -----------------------------------------------------------------------
+
+    def test_lowercase_identifiers_keyword_raises_index_error(self):
+        # FLAG: get_identifiers does ``"identifiers" in zip_comment.lower()`` (case-
+        # insensitive check) but then splits on the literal string "Identifiers:"
+        # (title-case).  If the comment uses all-lowercase "identifiers:" the check
+        # passes but the split produces only one element, so [1] raises IndexError.
+        # This is a latent bug pinned as-is.
+        with pytest.raises(IndexError):
+            kce.get_identifiers("identifiers: foo:bar, baz:qux")
+
+    def test_uppercase_identifiers_keyword_raises_index_error(self):
+        # FLAG: same bug — "IDENTIFIERS:" passes the .lower() check but not the
+        # title-case split.
+        with pytest.raises(IndexError):
+            kce.get_identifiers("IDENTIFIERS: foo:bar, baz:qux")
+
+
+# ===========================================================================
+# get_shortened_title
+# ===========================================================================
+
+class TestGetShortenedTitle:
+    """Characterize get_shortened_title — splits on `` - `` or ``: ``."""
+
+    def test_returns_str(self):
+        assert isinstance(kce.get_shortened_title("Naruto: The Clash"), str)
+
+    def test_colon_separator_returns_prefix(self):
+        assert kce.get_shortened_title("Naruto: The Clash of Ninja") == "Naruto"
+
+    def test_space_dash_space_separator_returns_prefix(self):
+        assert kce.get_shortened_title("Attack on Titan - Before the Fall") == "Attack on Titan"
+
+    def test_no_separator_returns_empty_string(self):
+        assert kce.get_shortened_title("My Hero Academia") == ""
+
+    def test_no_separator_plain_returns_empty_string(self):
+        assert kce.get_shortened_title("No Colon Or Dash") == ""
+
+    def test_inline_dash_without_spaces_not_matched(self):
+        # "One-Punch Man" has a dash but NOT surrounded by spaces, so no match.
+        assert kce.get_shortened_title("One-Punch Man") == ""
+
+    def test_multiple_separators_first_wins(self):
+        # Both ':' and ' - ' present; the regex strips from the first match.
+        assert kce.get_shortened_title("Solo Leveling: Ragnarok - Extra") == "Solo Leveling"
+
+    def test_multiple_colons_first_wins(self):
+        assert kce.get_shortened_title("A: B: C") == "A"
+
+    def test_single_char_before_separator(self):
+        assert kce.get_shortened_title("A - B") == "A"
+
+    def test_space_colon_space_separator(self):
+        # 'A : B' — regex matches `: ` with leading space.
+        assert kce.get_shortened_title("A : B") == "A"
+
+    def test_colon_no_trailing_space_not_matched(self):
+        # 'Title:' has no trailing space after the colon → no regex match.
+        assert kce.get_shortened_title("Title:") == ""
+
+    def test_empty_string_returns_empty(self):
+        assert kce.get_shortened_title("") == ""
+
+
+# ===========================================================================
+# Volume golden snapshots — upgrade_to_file_class + upgrade_to_volume_class
+# ===========================================================================
+
+class TestVolumeGoldenSnapshots:
+    """Pin the production parsing pipeline end-to-end with test_mode=True.
+
+    test_mode=True implies:
+      - skip_release_year=True  → volume_year is always None
+      - skip_publisher=True     → publisher.from_meta is always None
+      - skip_premium_content=True → is_premium is always False
+    Release group lookup is also skipped in test_mode (skip_release_group default
+    False but get_extra_from_group reads kce.release_groups which is [] by default,
+    so release_group is always '' in the default test fixture).
+    """
+
+    # -----------------------------------------------------------------------
+    # Standard volume with digital/group extras
+    # -----------------------------------------------------------------------
+
+    def test_standard_volume_file_type(self):
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        assert vols[0].file_type == "volume"
+
+    def test_standard_volume_series_name(self):
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        assert vols[0].series_name == "Naruto"
+
+    def test_standard_volume_number(self):
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        assert vols[0].volume_number == 1
+
+    def test_standard_volume_index_number(self):
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        assert vols[0].index_number == 1
+
+    def test_standard_volume_extension(self):
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        assert vols[0].extension == ".cbz"
+
+    def test_standard_volume_year_none_in_test_mode(self):
+        # test_mode=True skips year lookup → always None.
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        assert vols[0].volume_year is None
+
+    def test_standard_volume_release_group_empty_no_groups_configured(self):
+        # kce.release_groups == [] (default) → release_group is ''.
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        assert vols[0].release_group == ""
+
+    def test_standard_volume_extras(self):
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        assert vols[0].extras == ["(Digital)", "[Group]"]
+
+    def test_standard_volume_is_not_one_shot(self):
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        assert vols[0].is_one_shot is False
+
+    def test_standard_volume_part_is_empty_string(self):
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        assert vols[0].volume_part == ""
+
+    def test_standard_volume_publisher_from_meta_none(self):
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        pub = vols[0].publisher
+        assert pub.from_meta is None
+
+    def test_standard_volume_publisher_from_name_none(self):
+        vols = _make_volumes(["Naruto v01 (2021) (Digital) [Group].cbz"])
+        pub = vols[0].publisher
+        assert pub.from_name is None
+
+    # -----------------------------------------------------------------------
+    # Volume with subtitle (space-dash-space separator)
+    # -----------------------------------------------------------------------
+
+    def test_subtitle_series_name_full(self):
+        vols = _make_volumes(["Attack on Titan - Before the Fall v01.cbz"])
+        assert vols[0].series_name == "Attack on Titan - Before the Fall"
+
+    def test_subtitle_shortened_series_name(self):
+        vols = _make_volumes(["Attack on Titan - Before the Fall v01.cbz"])
+        assert vols[0].shortened_series_name == "Attack on Titan"
+
+    def test_subtitle_subtitle_field_empty(self):
+        # The subtitle field is set by get_subtitle_from_title; with no recognized
+        # subtitle pattern the field is '' for this input.
+        vols = _make_volumes(["Attack on Titan - Before the Fall v01.cbz"])
+        assert vols[0].subtitle == ""
+
+    def test_subtitle_volume_number(self):
+        vols = _make_volumes(["Attack on Titan - Before the Fall v01.cbz"])
+        assert vols[0].volume_number == 1
+
+    def test_subtitle_extras_empty(self):
+        vols = _make_volumes(["Attack on Titan - Before the Fall v01.cbz"])
+        assert vols[0].extras == []
+
+    def test_subtitle_multi_volume_false(self):
+        vols = _make_volumes(["Attack on Titan - Before the Fall v01.cbz"])
+        assert vols[0].multi_volume is False
+
+    # -----------------------------------------------------------------------
+    # Volume with part number — index_number = volume_number + part/10
+    # -----------------------------------------------------------------------
+
+    def test_part_volume_number(self):
+        vols = _make_volumes(["My Hero Academia v01 Part 2 (2020) [Digital].cbz"])
+        assert vols[0].volume_number == 1
+
+    def test_part_volume_part(self):
+        vols = _make_volumes(["My Hero Academia v01 Part 2 (2020) [Digital].cbz"])
+        assert vols[0].volume_part == 2
+
+    def test_part_index_number(self):
+        # index_number = volume_number + volume_part / 10 = 1 + 2/10 = 1.2
+        vols = _make_volumes(["My Hero Academia v01 Part 2 (2020) [Digital].cbz"])
+        assert vols[0].index_number == 1.2
+
+    def test_part_extras_include_part_tag(self):
+        vols = _make_volumes(["My Hero Academia v01 Part 2 (2020) [Digital].cbz"])
+        assert "(Part 2)" in vols[0].extras
+
+    # -----------------------------------------------------------------------
+    # Chapter file
+    # -----------------------------------------------------------------------
+
+    def test_chapter_file_type(self):
+        vols = _make_volumes(["Naruto Chapter 001.cbz"])
+        assert vols[0].file_type == "chapter"
+
+    def test_chapter_volume_number(self):
+        vols = _make_volumes(["Naruto Chapter 001.cbz"])
+        assert vols[0].volume_number == 1
+
+    def test_chapter_series_name(self):
+        vols = _make_volumes(["Naruto Chapter 001.cbz"])
+        assert vols[0].series_name == "Naruto"
+
+    # -----------------------------------------------------------------------
+    # One-shot: no volume number in test_mode → is_one_shot=True, volume_number=1
+    # -----------------------------------------------------------------------
+
+    def test_one_shot_detection_no_volume_number(self):
+        vols = _make_volumes(["Koe no Katachi (2013) (Digital) [Group].cbz"])
+        assert vols[0].is_one_shot is True
+
+    def test_one_shot_volume_number_set_to_1(self):
+        # When is_one_shot is True the pipeline sets volume_number = 1.
+        vols = _make_volumes(["Koe no Katachi (2013) (Digital) [Group].cbz"])
+        assert vols[0].volume_number == 1
+
+    def test_one_shot_index_number_set_to_1(self):
+        vols = _make_volumes(["Koe no Katachi (2013) (Digital) [Group].cbz"])
+        assert vols[0].index_number == 1
+
+    def test_one_shot_extras(self):
+        vols = _make_volumes(["Koe no Katachi (2013) (Digital) [Group].cbz"])
+        assert vols[0].extras == ["(Digital)", "[Group]"]
+
+    def test_volume_with_number_is_not_one_shot(self):
+        vols = _make_volumes(["Berserk v40 (2020) (Digital) [Group].cbz"])
+        assert vols[0].is_one_shot is False
+        assert vols[0].volume_number == 40
+
+    # -----------------------------------------------------------------------
+    # Multi-volume file (hyphenated range)
+    # -----------------------------------------------------------------------
+
+    def test_multi_volume_flag_true(self):
+        vols = _make_volumes(["Naruto v01-03 (2021) (Digital).cbz"])
+        assert vols[0].multi_volume is True
+
+    def test_multi_volume_number_is_list(self):
+        vols = _make_volumes(["Naruto v01-03 (2021) (Digital).cbz"])
+        assert vols[0].volume_number == [1, 3]
+
+    def test_multi_volume_index_number_is_list(self):
+        vols = _make_volumes(["Naruto v01-03 (2021) (Digital).cbz"])
+        assert vols[0].index_number == [1, 3]
+
+    def test_multi_volume_extras(self):
+        vols = _make_volumes(["Naruto v01-03 (2021) (Digital).cbz"])
+        assert vols[0].extras == ["(Digital)"]
+
+    # -----------------------------------------------------------------------
+    # Float volume number (e.g. v10.5 side-story)
+    # -----------------------------------------------------------------------
+
+    def test_float_volume_number(self):
+        vols = _make_volumes(["One Piece v10.5 (Digital).cbz"])
+        assert vols[0].volume_number == 10.5
+
+    def test_float_volume_part_is_empty(self):
+        # 10.5 is already a float; volume_part stays '' (no Part keyword).
+        vols = _make_volumes(["One Piece v10.5 (Digital).cbz"])
+        assert vols[0].volume_part == ""
+
+    def test_float_volume_index_equals_volume_number(self):
+        vols = _make_volumes(["One Piece v10.5 (Digital).cbz"])
+        assert vols[0].index_number == 10.5
+
+    # -----------------------------------------------------------------------
+    # epub extension
+    # -----------------------------------------------------------------------
+
+    def test_epub_extension(self):
+        vols = _make_volumes(["Sword Art Online v01.epub"])
+        assert vols[0].extension == ".epub"
+
+    def test_epub_file_type_volume(self):
+        vols = _make_volumes(["Sword Art Online v01.epub"])
+        assert vols[0].file_type == "volume"
+
+    def test_epub_series_name(self):
+        vols = _make_volumes(["Sword Art Online v01.epub"])
+        assert vols[0].series_name == "Sword Art Online"
+
+    def test_epub_volume_number(self):
+        vols = _make_volumes(["Sword Art Online v01.epub"])
+        assert vols[0].volume_number == 1
+
+    # -----------------------------------------------------------------------
+    # Batch: multiple files → multiple Volume objects
+    # -----------------------------------------------------------------------
+
+    def test_batch_length(self):
+        names = ["Naruto v01.cbz", "Naruto v02.cbz", "Naruto v03.cbz"]
+        vols = _make_volumes(names)
+        assert len(vols) == 3
+
+    def test_batch_volume_numbers(self):
+        names = ["Naruto v01.cbz", "Naruto v02.cbz", "Naruto v03.cbz"]
+        vols = _make_volumes(names)
+        nums = [v.volume_number for v in vols]
+        assert nums == [1, 2, 3]
+
+    def test_batch_all_same_series(self):
+        names = ["Naruto v01.cbz", "Naruto v02.cbz"]
+        vols = _make_volumes(names)
+        assert all(v.series_name == "Naruto" for v in vols)
+
+    # -----------------------------------------------------------------------
+    # Empty input
+    # -----------------------------------------------------------------------
+
+    def test_empty_file_list_returns_empty(self):
+        files = kce.upgrade_to_file_class([], "/tmp/nope", test_mode=True)
+        assert files == []
+
+    def test_empty_volume_list_returns_empty(self):
+        result = kce.upgrade_to_volume_class([], test_mode=True)
+        assert result == []

--- a/tests/engine/test_volume_golden.py
+++ b/tests/engine/test_volume_golden.py
@@ -1,0 +1,941 @@
+"""Full-field GOLDEN SNAPSHOT tests for the Volume parsing call-graph.
+
+Each test builds real Volume objects through the production pipeline:
+
+    files = kce.upgrade_to_file_class([name], root, test_mode=True)
+    vols  = kce.upgrade_to_volume_class(files, test_mode=True)
+
+and then pins EVERY observable field precisely.
+
+Key test_mode=True effects (characterised and pinned as-is):
+  * ``skip_release_year=True``  → ``volume_year`` is always ``None``
+  * ``skip_publisher=True``     → ``publisher`` is always ``Publisher(None, None)``
+  * ``skip_premium_content=True``→ ``is_premium`` is always ``False``
+  * ``release_group`` is ``''`` because no release-group list is loaded in isolation
+
+All values were observed by running the relevant snippet in the project .venv
+before writing the assertion — no values were guessed.
+
+Verified with:
+    .venv/bin/python3 -c "import komga_cover_extractor as kce; ..."
+on the tests/upgrade-scoring-engine branch.
+"""
+
+from __future__ import annotations
+
+import regex
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _build(filename: str, root: str = "/tmp/nope"):
+    """Return (File, Volume) pair through the production pipeline (test_mode=True)."""
+    files = kce.upgrade_to_file_class([filename], root, test_mode=True)
+    assert files, f"upgrade_to_file_class returned empty list for {filename!r}"
+    vols = kce.upgrade_to_volume_class(files, test_mode=True)
+    assert vols, f"upgrade_to_volume_class returned empty list for {filename!r}"
+    return files[0], vols[0]
+
+
+# ===========================================================================
+# Golden 1 — Mushoku Tensei v01 (2021) (Digital) [Seven Seas].cbz
+# ===========================================================================
+
+class TestMushokuTenseiGolden:
+    """Full-field pin for a standard single-volume manga CBZ.
+
+    This is the canonical integration fixture: it exercises file-class
+    parsing, volume-class parsing, extras extraction, one-shot check,
+    multi-volume check, subtitle extraction, and part detection all at once.
+
+    All assertions were verified against observed production output.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _build_vol(self):
+        self.f, self.v = _build(
+            "Mushoku Tensei v01 (2021) (Digital) [Seven Seas].cbz"
+        )
+
+    # ------------------------------------------------------------------
+    # File-class layer
+    # ------------------------------------------------------------------
+
+    def test_file_name(self):
+        assert self.f.name == "Mushoku Tensei v01 (2021) (Digital) [Seven Seas].cbz"
+
+    def test_file_extension(self):
+        assert self.f.extension == ".cbz"
+
+    def test_file_type(self):
+        # upgrade_to_file_class classifies this as a volume, not a chapter
+        assert self.f.file_type == "volume"
+
+    def test_file_volume_number(self):
+        assert self.f.volume_number == 1
+        assert isinstance(self.f.volume_number, int)
+
+    def test_file_header_extension(self):
+        # test_mode=True: no real header read; header_extension stays None
+        assert self.f.header_extension is None
+
+    def test_file_basename(self):
+        assert self.f.basename == "Mushoku Tensei"
+
+    def test_file_root(self):
+        assert self.f.root == "/tmp/nope"
+
+    def test_file_extensionless_name(self):
+        assert self.f.extensionless_name == "Mushoku Tensei v01 (2021) (Digital) [Seven Seas]"
+
+    def test_file_extensionless_path(self):
+        assert self.f.extensionless_path == (
+            "/tmp/nope/Mushoku Tensei v01 (2021) (Digital) [Seven Seas]"
+        )
+
+    # ------------------------------------------------------------------
+    # Volume-class identification fields
+    # ------------------------------------------------------------------
+
+    def test_series_name(self):
+        assert self.v.series_name == "Mushoku Tensei"
+
+    def test_shortened_series_name(self):
+        # No dash/colon in the base title → no shortened form
+        assert self.v.shortened_series_name == ""
+
+    def test_volume_number_value(self):
+        assert self.v.volume_number == 1
+
+    def test_volume_number_type(self):
+        assert isinstance(self.v.volume_number, int)
+
+    def test_index_number_value(self):
+        # No part → index_number == volume_number
+        assert self.v.index_number == 1
+
+    def test_index_number_type(self):
+        assert isinstance(self.v.index_number, int)
+
+    def test_volume_part_empty(self):
+        assert self.v.volume_part == ""
+        assert isinstance(self.v.volume_part, str)
+
+    def test_file_type_volume(self):
+        assert self.v.file_type == "volume"
+
+    def test_extension(self):
+        assert self.v.extension == ".cbz"
+
+    def test_header_extension_none(self):
+        assert self.v.header_extension is None
+
+    # ------------------------------------------------------------------
+    # Extras (Digital + group bracket)
+    # ------------------------------------------------------------------
+
+    def test_extras_exact_list(self):
+        # Both (Digital) and [Seven Seas] survive extras extraction.
+        assert self.v.extras == ["(Digital)", "[Seven Seas]"]
+
+    def test_extras_type(self):
+        assert isinstance(self.v.extras, list)
+        assert all(isinstance(x, str) for x in self.v.extras)
+
+    # ------------------------------------------------------------------
+    # Boolean flags
+    # ------------------------------------------------------------------
+
+    def test_is_one_shot_false(self):
+        # Has a volume number → not a one-shot
+        assert self.v.is_one_shot is False
+
+    def test_is_premium_false(self):
+        # test_mode=True skips premium detection → always False
+        assert self.v.is_premium is False
+
+    def test_multi_volume_false(self):
+        # No range in name → multi_volume is False (not None)
+        assert self.v.multi_volume is False
+
+    # ------------------------------------------------------------------
+    # Publisher (test_mode skips all lookups)
+    # ------------------------------------------------------------------
+
+    def test_publisher_type(self):
+        assert isinstance(self.v.publisher, kce.Publisher)
+
+    def test_publisher_from_meta_none(self):
+        # test_mode=True skips internal metadata → from_meta is None
+        assert self.v.publisher.from_meta is None
+
+    def test_publisher_from_name_none(self):
+        # test_mode=True skips publisher lookup → from_name is None
+        assert self.v.publisher.from_name is None
+
+    # ------------------------------------------------------------------
+    # Subtitle
+    # ------------------------------------------------------------------
+
+    def test_subtitle_empty(self):
+        # No dash + year/Digital marker combo in standard position → no subtitle
+        assert self.v.subtitle == ""
+        assert isinstance(self.v.subtitle, str)
+
+    # ------------------------------------------------------------------
+    # Release group + year (test_mode effects)
+    # ------------------------------------------------------------------
+
+    def test_release_group_empty_under_test_mode(self):
+        # FLAG: release_group is '' under test_mode (no group list loaded and
+        # skip_release_group is NOT forced True by test_mode — the '' comes
+        # from get_extra_from_group returning '' when release_groups is []).
+        assert self.v.release_group == ""
+        assert isinstance(self.v.release_group, str)
+
+    def test_volume_year_none_under_test_mode(self):
+        # test_mode=True forces skip_release_year=True → volume_year is None
+        # even though '(2021)' appears in the filename.
+        assert self.v.volume_year is None
+
+    # ------------------------------------------------------------------
+    # Path / name fields pass-through
+    # ------------------------------------------------------------------
+
+    def test_name_passthrough(self):
+        assert self.v.name == "Mushoku Tensei v01 (2021) (Digital) [Seven Seas].cbz"
+
+    def test_basename_passthrough(self):
+        assert self.v.basename == "Mushoku Tensei"
+
+    def test_extensionless_name(self):
+        assert self.v.extensionless_name == (
+            "Mushoku Tensei v01 (2021) (Digital) [Seven Seas]"
+        )
+
+    def test_root_passthrough(self):
+        assert self.v.root == "/tmp/nope"
+
+    def test_path_passthrough(self):
+        assert self.v.path == (
+            "/tmp/nope/Mushoku Tensei v01 (2021) (Digital) [Seven Seas].cbz"
+        )
+
+    def test_extensionless_path(self):
+        assert self.v.extensionless_path == (
+            "/tmp/nope/Mushoku Tensei v01 (2021) (Digital) [Seven Seas]"
+        )
+
+
+# ===========================================================================
+# Golden 2 — Series v01-03 (2021) (Digital) [Group].cbz — MULTI-VOLUME
+# ===========================================================================
+
+class TestMultiVolumeGolden:
+    """Full-field pin for a range-numbered multi-volume CBZ.
+
+    The key invariants: volume_number is a list, multi_volume is truthy.
+    All assertions were verified against observed production output.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _build_vol(self):
+        self.f, self.v = _build(
+            "Series v01-03 (2021) (Digital) [Group].cbz"
+        )
+
+    def test_series_name(self):
+        assert self.v.series_name == "Series"
+
+    def test_volume_number_is_list(self):
+        assert self.v.volume_number == [1, 3]
+        assert isinstance(self.v.volume_number, list)
+
+    def test_volume_number_elements_are_int(self):
+        for x in self.v.volume_number:
+            assert isinstance(x, int)
+
+    def test_index_number_is_list(self):
+        # No part: index_number mirrors volume_number for multi-volume
+        assert self.v.index_number == [1, 3]
+        assert isinstance(self.v.index_number, list)
+
+    def test_index_number_elements_are_int(self):
+        for x in self.v.index_number:
+            assert isinstance(x, int)
+
+    def test_multi_volume_truthy(self):
+        assert self.v.multi_volume
+
+    def test_multi_volume_is_true(self):
+        assert self.v.multi_volume is True
+
+    def test_is_one_shot_false(self):
+        assert self.v.is_one_shot is False
+
+    def test_extras_exact(self):
+        assert self.v.extras == ["(Digital)", "[Group]"]
+
+    def test_volume_part_empty(self):
+        assert self.v.volume_part == ""
+
+    def test_subtitle_empty(self):
+        assert self.v.subtitle == ""
+
+    def test_release_group_empty(self):
+        assert self.v.release_group == ""
+
+    def test_volume_year_none(self):
+        assert self.v.volume_year is None
+
+    def test_is_premium_false(self):
+        assert self.v.is_premium is False
+
+    def test_publisher_from_meta_none(self):
+        assert self.v.publisher.from_meta is None
+
+    def test_publisher_from_name_none(self):
+        assert self.v.publisher.from_name is None
+
+    def test_file_type(self):
+        assert self.v.file_type == "volume"
+
+    def test_extension(self):
+        assert self.v.extension == ".cbz"
+
+    def test_name(self):
+        assert self.v.name == "Series v01-03 (2021) (Digital) [Group].cbz"
+
+    def test_shortened_series_name(self):
+        assert self.v.shortened_series_name == ""
+
+
+# ===========================================================================
+# Golden 3 — Sword Art Online v01 (2020) (Digital) [Yen Press].epub — NOVEL
+# ===========================================================================
+
+class TestEpubNovelGolden:
+    """Full-field pin for a standard .epub light novel.
+
+    Verifies that the parsing pipeline correctly handles epub extension
+    and that the series name is preserved without modification.
+    All assertions were verified against observed production output.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _build_vol(self):
+        self.f, self.v = _build(
+            "Sword Art Online v01 (2020) (Digital) [Yen Press].epub"
+        )
+
+    def test_series_name(self):
+        assert self.v.series_name == "Sword Art Online"
+
+    def test_shortened_series_name_empty(self):
+        # No dash/colon separator in base title
+        assert self.v.shortened_series_name == ""
+
+    def test_extension_is_epub(self):
+        assert self.v.extension == ".epub"
+
+    def test_file_type(self):
+        assert self.v.file_type == "volume"
+
+    def test_volume_number(self):
+        assert self.v.volume_number == 1
+        assert isinstance(self.v.volume_number, int)
+
+    def test_index_number(self):
+        assert self.v.index_number == 1
+        assert isinstance(self.v.index_number, int)
+
+    def test_volume_part_empty(self):
+        assert self.v.volume_part == ""
+
+    def test_extras(self):
+        assert self.v.extras == ["(Digital)", "[Yen Press]"]
+
+    def test_is_one_shot_false(self):
+        assert self.v.is_one_shot is False
+
+    def test_is_premium_false(self):
+        # test_mode=True skips premium content check for epub too
+        assert self.v.is_premium is False
+
+    def test_multi_volume_false(self):
+        assert self.v.multi_volume is False
+
+    def test_publisher_from_meta_none(self):
+        assert self.v.publisher.from_meta is None
+
+    def test_publisher_from_name_none(self):
+        assert self.v.publisher.from_name is None
+
+    def test_subtitle_empty(self):
+        assert self.v.subtitle == ""
+
+    def test_release_group_empty(self):
+        assert self.v.release_group == ""
+
+    def test_volume_year_none(self):
+        assert self.v.volume_year is None
+
+    def test_header_extension_none(self):
+        assert self.v.header_extension is None
+
+    def test_name(self):
+        assert self.v.name == "Sword Art Online v01 (2020) (Digital) [Yen Press].epub"
+
+    def test_basename(self):
+        assert self.v.basename == "Sword Art Online"
+
+    def test_root(self):
+        assert self.v.root == "/tmp/nope"
+
+
+# ===========================================================================
+# Golden 4 — My One Shot Story (2020) (Digital) [Group].cbz — ONE-SHOT
+# ===========================================================================
+
+class TestOneShotGolden:
+    """Full-field pin for a one-shot CBZ (no volume number in filename).
+
+    is_one_shot=True is set by kce.is_one_shot() and then the pipeline
+    forces volume_number=1 and index_number=1.
+    All assertions were verified against observed production output.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _build_vol(self):
+        self.f, self.v = _build(
+            "My One Shot Story (2020) (Digital) [Group].cbz"
+        )
+
+    def test_series_name(self):
+        assert self.v.series_name == "My One Shot Story"
+
+    def test_is_one_shot_true(self):
+        assert self.v.is_one_shot is True
+
+    def test_volume_number_forced_to_1(self):
+        # FLAG: is_one_shot=True forces volume_number to 1 via the pipeline
+        # (``if file_obj.is_one_shot: file_obj.volume_number = 1``), even though
+        # no volume number appears in the filename.
+        assert self.v.volume_number == 1
+        assert isinstance(self.v.volume_number, int)
+
+    def test_index_number_forced_to_1(self):
+        # index_number mirrors volume_number when no part is present
+        assert self.v.index_number == 1
+        assert isinstance(self.v.index_number, int)
+
+    def test_volume_part_empty(self):
+        assert self.v.volume_part == ""
+
+    def test_extras(self):
+        assert self.v.extras == ["(Digital)", "[Group]"]
+
+    def test_is_premium_false(self):
+        assert self.v.is_premium is False
+
+    def test_multi_volume_false(self):
+        assert self.v.multi_volume is False
+
+    def test_file_type(self):
+        # One-shots are classified as "volume" by default under test_mode=True
+        # (the chapter re-classification code path is skipped in test_mode)
+        assert self.v.file_type == "volume"
+
+    def test_extension(self):
+        assert self.v.extension == ".cbz"
+
+    def test_subtitle_empty(self):
+        assert self.v.subtitle == ""
+
+    def test_release_group_empty(self):
+        assert self.v.release_group == ""
+
+    def test_volume_year_none(self):
+        assert self.v.volume_year is None
+
+    def test_publisher_from_meta_none(self):
+        assert self.v.publisher.from_meta is None
+
+    def test_publisher_from_name_none(self):
+        assert self.v.publisher.from_name is None
+
+    def test_name(self):
+        assert self.v.name == "My One Shot Story (2020) (Digital) [Group].cbz"
+
+    def test_shortened_series_name_empty(self):
+        assert self.v.shortened_series_name == ""
+
+
+# ===========================================================================
+# Golden 5 — Some Series v02 Part 1 (2021) (Digital).cbz — VOLUME WITH PART
+# ===========================================================================
+
+class TestVolumePartGolden:
+    """Full-field pin for a volume that includes a Part designation.
+
+    Key invariants: volume_number (int), volume_part (int), index_number (float).
+    All assertions were verified against observed production output.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _build_vol(self):
+        self.f, self.v = _build(
+            "Some Series v02 Part 1 (2021) (Digital).cbz"
+        )
+
+    def test_series_name(self):
+        assert self.v.series_name == "Some Series"
+
+    def test_volume_number(self):
+        assert self.v.volume_number == 2
+        assert isinstance(self.v.volume_number, int)
+
+    def test_volume_part(self):
+        assert self.v.volume_part == 1
+        assert isinstance(self.v.volume_part, int)
+
+    def test_index_number_is_float(self):
+        # index_number = volume_number + (volume_part / 10) = 2 + 0.1 = 2.1
+        assert self.v.index_number == 2.1
+        assert isinstance(self.v.index_number, float)
+
+    def test_extras_contains_part(self):
+        # (Part 1) is extracted into extras along with (Digital)
+        assert self.v.extras == ["(Digital)", "(Part 1)"]
+
+    def test_is_one_shot_false(self):
+        assert self.v.is_one_shot is False
+
+    def test_multi_volume_false(self):
+        assert self.v.multi_volume is False
+
+    def test_is_premium_false(self):
+        assert self.v.is_premium is False
+
+    def test_subtitle_empty(self):
+        assert self.v.subtitle == ""
+
+    def test_release_group_empty(self):
+        assert self.v.release_group == ""
+
+    def test_volume_year_none(self):
+        assert self.v.volume_year is None
+
+    def test_file_type(self):
+        assert self.v.file_type == "volume"
+
+    def test_extension(self):
+        assert self.v.extension == ".cbz"
+
+    def test_name(self):
+        assert self.v.name == "Some Series v02 Part 1 (2021) (Digital).cbz"
+
+    def test_publisher_from_meta_none(self):
+        assert self.v.publisher.from_meta is None
+
+    def test_publisher_from_name_none(self):
+        assert self.v.publisher.from_name is None
+
+
+# ===========================================================================
+# Golden 6 — Overlord v01 - The Undead King (2015) (Digital) [Yen Press].cbz
+#            — VOLUME WITH SUBTITLE
+# ===========================================================================
+
+class TestSubtitleGolden:
+    """Full-field pin for a volume with an explicit subtitle.
+
+    The subtitle ``'The Undead King'`` is extracted because the filename
+    has both a dash separator and a ``(YYYY)``/``(Digital)`` marker.
+    All assertions were verified against observed production output.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _build_vol(self):
+        self.f, self.v = _build(
+            "Overlord v01 - The Undead King (2015) (Digital) [Yen Press].cbz"
+        )
+
+    def test_series_name(self):
+        assert self.v.series_name == "Overlord"
+
+    def test_subtitle(self):
+        assert self.v.subtitle == "The Undead King"
+        assert isinstance(self.v.subtitle, str)
+
+    def test_volume_number(self):
+        assert self.v.volume_number == 1
+        assert isinstance(self.v.volume_number, int)
+
+    def test_index_number(self):
+        assert self.v.index_number == 1
+        assert isinstance(self.v.index_number, int)
+
+    def test_volume_part_empty(self):
+        assert self.v.volume_part == ""
+
+    def test_extras(self):
+        assert self.v.extras == ["(Digital)", "[Yen Press]"]
+
+    def test_multi_volume_false(self):
+        assert self.v.multi_volume is False
+
+    def test_is_one_shot_false(self):
+        assert self.v.is_one_shot is False
+
+    def test_is_premium_false(self):
+        assert self.v.is_premium is False
+
+    def test_file_type(self):
+        assert self.v.file_type == "volume"
+
+    def test_extension(self):
+        assert self.v.extension == ".cbz"
+
+    def test_release_group_empty(self):
+        assert self.v.release_group == ""
+
+    def test_volume_year_none(self):
+        assert self.v.volume_year is None
+
+    def test_publisher_from_meta_none(self):
+        assert self.v.publisher.from_meta is None
+
+    def test_publisher_from_name_none(self):
+        assert self.v.publisher.from_name is None
+
+    def test_name(self):
+        assert self.v.name == "Overlord v01 - The Undead King (2015) (Digital) [Yen Press].cbz"
+
+
+# ===========================================================================
+# Golden 7 — Epub novel with shortened series name
+#            (Sword Art Online - Progressive v01 ...)
+# ===========================================================================
+
+class TestEpubWithShortenedTitleGolden:
+    """Full-field pin for an epub with a dash-separated subtitle in the series name.
+
+    The base series name contains `` - Progressive``, which causes
+    ``get_shortened_title`` to extract ``'Sword Art Online'`` as the shortened form.
+    All assertions were verified against observed production output.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _build_vol(self):
+        self.f, self.v = _build(
+            "Sword Art Online - Progressive v01 (2020) (Digital) [Yen Press].epub"
+        )
+
+    def test_series_name(self):
+        assert self.v.series_name == "Sword Art Online - Progressive"
+
+    def test_shortened_series_name(self):
+        # Dash in series title → shortened to the part before the dash
+        assert self.v.shortened_series_name == "Sword Art Online"
+
+    def test_extension(self):
+        assert self.v.extension == ".epub"
+
+    def test_volume_number(self):
+        assert self.v.volume_number == 1
+        assert isinstance(self.v.volume_number, int)
+
+    def test_index_number(self):
+        assert self.v.index_number == 1
+
+    def test_volume_part_empty(self):
+        assert self.v.volume_part == ""
+
+    def test_extras(self):
+        assert self.v.extras == ["(Digital)", "[Yen Press]"]
+
+    def test_is_one_shot_false(self):
+        assert self.v.is_one_shot is False
+
+    def test_is_premium_false(self):
+        assert self.v.is_premium is False
+
+    def test_multi_volume_false(self):
+        assert self.v.multi_volume is False
+
+    def test_subtitle_empty(self):
+        # The `` - Progressive`` is PART of the series name, not an episode subtitle
+        assert self.v.subtitle == ""
+
+    def test_release_group_empty(self):
+        assert self.v.release_group == ""
+
+    def test_volume_year_none(self):
+        assert self.v.volume_year is None
+
+    def test_file_type(self):
+        assert self.v.file_type == "volume"
+
+    def test_publisher_from_meta_none(self):
+        assert self.v.publisher.from_meta is None
+
+    def test_publisher_from_name_none(self):
+        assert self.v.publisher.from_name is None
+
+    def test_name(self):
+        assert self.v.name == (
+            "Sword Art Online - Progressive v01 (2020) (Digital) [Yen Press].epub"
+        )
+
+
+# ===========================================================================
+# Scoring engine — get_keyword_scores with real keyword config
+# ===========================================================================
+
+class TestKeywordScoring:
+    """Pin ``kce.get_keyword_scores`` behaviour.
+
+    With the default (empty) ranked_keywords the score is always 0.0.
+    After injecting a small known config, scoring reflects matched keywords.
+    The autouse isolated_globals fixture restores ranked_keywords/compiled_searches
+    after each test.
+    """
+
+    def test_empty_keywords_returns_zero_score(self):
+        """Default state: ranked_keywords=[] → score 0.0, no tags matched.
+
+        Observed: RankedKeywordResult(total_score=0.0, keywords=[]).
+        """
+        _, v = _build("Mushoku Tensei v01 (2021) (Digital) [Seven Seas].cbz")
+        results = kce.get_keyword_scores([v])
+        assert len(results) == 1
+        r = results[0]
+        assert r.total_score == 0.0
+        assert r.keywords == []
+
+    def test_matching_keyword_contributes_score(self):
+        """'Digital' keyword with score 10.0 fires on a filename containing
+        '(Digital)'.
+
+        Observed: total_score=10.0, one keyword matched.
+        """
+        kce.ranked_keywords = [kce.Keyword("Digital", 10.0, "both")]
+        kce.compiled_searches = [
+            regex.compile("Digital", regex.IGNORECASE)
+        ]
+        _, v = _build("Mushoku Tensei v01 (2021) (Digital) [Seven Seas].cbz")
+        results = kce.get_keyword_scores([v])
+        r = results[0]
+        assert r.total_score == 10.0
+        assert len(r.keywords) == 1
+        assert r.keywords[0].score == 10.0
+
+    def test_two_matching_keywords_sum_scores(self):
+        """Two keywords both match → scores are summed.
+
+        Observed: total_score=15.0 (Digital=10.0 + [Seven Seas]=5.0).
+        """
+        kce.ranked_keywords = [
+            kce.Keyword("Digital", 10.0, "both"),
+            kce.Keyword(r"\[Seven Seas\]", 5.0, "both"),
+        ]
+        kce.compiled_searches = [
+            regex.compile(k.name, regex.IGNORECASE) for k in kce.ranked_keywords
+        ]
+        _, v = _build("Mushoku Tensei v01 (2021) (Digital) [Seven Seas].cbz")
+        results = kce.get_keyword_scores([v])
+        r = results[0]
+        assert r.total_score == 15.0
+        assert len(r.keywords) == 2
+
+    def test_non_matching_keyword_contributes_zero(self):
+        """A keyword that does not match the filename does not contribute.
+
+        Observed: total_score=0.0 for a release without 'Premium'.
+        """
+        kce.ranked_keywords = [kce.Keyword("Premium", -5.0, "both")]
+        kce.compiled_searches = [
+            regex.compile("Premium", regex.IGNORECASE)
+        ]
+        _, v = _build("Mushoku Tensei v01 (2021) (Digital) [Seven Seas].cbz")
+        results = kce.get_keyword_scores([v])
+        r = results[0]
+        assert r.total_score == 0.0
+        assert r.keywords == []
+
+    def test_result_type_is_ranked_keyword_result(self):
+        """Return value is a list of RankedKeywordResult objects."""
+        _, v = _build("Mushoku Tensei v01 (2021) (Digital) [Seven Seas].cbz")
+        results = kce.get_keyword_scores([v])
+        assert isinstance(results, list)
+        assert isinstance(results[0], kce.RankedKeywordResult)
+
+    def test_multiple_releases_scored_independently(self):
+        """Two releases scored in one call: each gets its own result entry.
+
+        Digital release scores 10.0; plain release scores 0.0.
+        Observed: [10.0, 0.0].
+        """
+        kce.ranked_keywords = [kce.Keyword("Digital", 10.0, "both")]
+        kce.compiled_searches = [
+            regex.compile("Digital", regex.IGNORECASE)
+        ]
+        _, v_digital = _build("Series v01 (Digital).cbz")
+        _, v_plain = _build("Series v01.cbz")
+        results = kce.get_keyword_scores([v_digital, v_plain])
+        assert len(results) == 2
+        assert results[0].total_score == 10.0
+        assert results[1].total_score == 0.0
+
+
+# ===========================================================================
+# is_upgradeable — upgrade decision logic
+# ===========================================================================
+
+class TestIsUpgradeable:
+    """Pin ``kce.is_upgradeable`` through the production scoring pipeline.
+
+    is_upgradeable calls get_keyword_scores and compares total_score values.
+    An UpgradeResult with is_upgrade=True means the downloaded release has a
+    strictly higher score than the current.
+    All assertions were verified against observed production output.
+    """
+
+    def _setup_keywords(self):
+        """Install a minimal known keyword config."""
+        kce.ranked_keywords = [
+            kce.Keyword("Digital", 10.0, "both"),
+            kce.Keyword(r"\[Seven Seas\]", 5.0, "both"),
+        ]
+        kce.compiled_searches = [
+            regex.compile(k.name, regex.IGNORECASE) for k in kce.ranked_keywords
+        ]
+
+    def test_higher_score_is_upgrade_true(self):
+        """Downloaded release with more matching keywords scores higher → upgrade.
+
+        digital+seven_seas (15.0) > seven_seas_only (5.0) → is_upgrade=True.
+        """
+        self._setup_keywords()
+        _, dl = _build("Mushoku Tensei v01 (Digital) [Seven Seas].cbz")
+        _, cur = _build("Mushoku Tensei v01 [Seven Seas].cbz")
+        result = kce.is_upgradeable(dl, cur)
+        assert result.is_upgrade is True
+        assert result.downloaded_ranked_result.total_score == 15.0
+        assert result.current_ranked_result.total_score == 5.0
+
+    def test_lower_score_is_upgrade_false(self):
+        """Downloaded release with fewer matched keywords → not an upgrade."""
+        self._setup_keywords()
+        _, dl = _build("Mushoku Tensei v01 [Seven Seas].cbz")
+        _, cur = _build("Mushoku Tensei v01 (Digital) [Seven Seas].cbz")
+        result = kce.is_upgradeable(dl, cur)
+        assert result.is_upgrade is False
+
+    def test_equal_score_is_upgrade_false(self):
+        """Equal scores → not an upgrade (strictly greater is required)."""
+        self._setup_keywords()
+        _, dl = _build("Mushoku Tensei v01 (Digital).cbz")
+        _, cur = _build("Mushoku Tensei v01 (Digital).cbz")
+        result = kce.is_upgradeable(dl, cur)
+        assert result.is_upgrade is False
+
+    def test_same_name_uses_same_ranked_result_object(self):
+        """When downloaded and current have the same name, get_keyword_scores is
+        called once and the single result is shared for both sides.
+
+        Observed: result.downloaded_ranked_result is result.current_ranked_result.
+        """
+        self._setup_keywords()
+        _, v = _build("Mushoku Tensei v01 (Digital) [Seven Seas].cbz")
+        result = kce.is_upgradeable(v, v)
+        assert result.downloaded_ranked_result is result.current_ranked_result
+
+    def test_result_type_is_upgrade_result(self):
+        """Return type is UpgradeResult."""
+        _, v = _build("Series v01.cbz")
+        result = kce.is_upgradeable(v, v)
+        assert isinstance(result, kce.UpgradeResult)
+
+    def test_no_keywords_both_score_zero_is_upgrade_false(self):
+        """With empty ranked_keywords, all releases score 0.0 → never an upgrade."""
+        # ranked_keywords is [] by default (autouse fixture restores it)
+        _, dl = _build("Series v01 (Digital).cbz")
+        _, cur = _build("Series v01.cbz")
+        result = kce.is_upgradeable(dl, cur)
+        assert result.is_upgrade is False
+        assert result.downloaded_ranked_result.total_score == 0.0
+        assert result.current_ranked_result.total_score == 0.0
+
+
+# ===========================================================================
+# get_highest_release
+# ===========================================================================
+
+class TestGetHighestRelease:
+    """Pin ``kce.get_highest_release`` behaviour.
+
+    When ``use_latest_volume_cover_as_series_cover`` is False (default),
+    the function always returns ``''``.  When enabled it returns the maximum
+    value from the tuple.
+    All assertions were verified against observed production output.
+    """
+
+    def test_toggle_off_returns_empty_string(self):
+        """Default toggle=False: always returns '' regardless of input.
+
+        Observed: ''.
+        """
+        assert kce.use_latest_volume_cover_as_series_cover is False
+        result = kce.get_highest_release((1, 2, 3, 4, 5))
+        assert result == ""
+
+    def test_toggle_on_simple_ints_returns_max(self):
+        """toggle=True + plain ints (no list/tuple items) → max() result.
+
+        Observed: 5.
+        """
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        result = kce.get_highest_release((1, 2, 3, 4, 5))
+        assert result == 5
+
+    def test_toggle_on_mixed_empty_string_returns_max_int(self):
+        """toggle=True + mixed ('', int, int): empty string is skipped;
+        max integer wins.
+
+        Observed: 2 for ('', 1, 2).
+        """
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        result = kce.get_highest_release(("", 1, 2))
+        assert result == 2
+
+    def test_toggle_off_empty_tuple_returns_empty_string(self):
+        """Empty release tuple with toggle off → ''.
+
+        Observed: ''.
+        """
+        assert kce.use_latest_volume_cover_as_series_cover is False
+        result = kce.get_highest_release(())
+        assert result == ""
+
+    def test_return_type_is_string_when_toggle_off(self):
+        """Return type is str (not int) when toggle is off."""
+        result = kce.get_highest_release((1, 2))
+        assert isinstance(result, str)
+
+    def test_return_type_is_int_when_toggle_on_all_ints(self):
+        """Return type is int when toggle is on and all elements are plain ints."""
+        kce.use_latest_volume_cover_as_series_cover = True
+        kce.get_highest_release.cache_clear()
+        result = kce.get_highest_release((3, 7, 2))
+        assert isinstance(result, int)
+        assert result == 7

--- a/tests/external/test_bookwalker.py
+++ b/tests/external/test_bookwalker.py
@@ -1,0 +1,81 @@
+"""Characterization tests for the Bookwalker scraping entrypoint scrape_url.
+
+scrape_url builds a requests.Session via get_session_object(url) and calls
+``.get`` on it, so we patch ``kce.get_session_object`` (NOT ``kce.requests``) to
+inject a fake session — the Session-based path the conftest mock_requests
+fixture intentionally does not cover.
+
+Pinned behavior:
+  * 200 -> returns a BeautifulSoup over response.content
+  * 403 -> raises a PLAIN Exception immediately (tenacity only retries
+    requests.exceptions.RequestException, so a 403 hard-block is re-raised at once)
+  * a RequestException -> retried stop_after_attempt(3) times, then the
+    retry_error_callback returns None (tenacity's wait is neutralized here by
+    patching time.sleep so the test is fast).
+"""
+
+import pytest
+
+import komga_cover_extractor as kce
+
+pytestmark = pytest.mark.external
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, content=b""):
+        self.status_code = status_code
+        self.content = content
+
+
+class _FakeSession:
+    """Stand-in for requests.Session: records .get calls, returns/raises queued."""
+
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    def get(self, **kwargs):
+        self.calls.append(kwargs)
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+def _patch_session(monkeypatch, session):
+    monkeypatch.setattr(kce, "get_session_object", lambda url: session)
+    return session
+
+
+class TestScrapeUrl:
+    def test_200_returns_soup(self, monkeypatch):
+        html = b"<html><body><h1 id='title'>Hello</h1></body></html>"
+        session = _patch_session(monkeypatch, _FakeSession(_FakeResp(200, html)))
+        soup = kce.scrape_url("https://bookwalker.jp/series/123")
+        # BeautifulSoup object: can query the parsed DOM
+        assert soup is not None
+        assert soup.find(id="title").get_text() == "Hello"
+        assert len(session.calls) == 1
+
+    def test_403_raises_immediately_no_retry(self, monkeypatch):
+        session = _patch_session(monkeypatch, _FakeSession(_FakeResp(403, b"")))
+        with pytest.raises(Exception, match="rate-limited"):
+            kce.scrape_url("https://bookwalker.jp/series/123")
+        # 403 is re-raised on the FIRST attempt (no retry loop)
+        assert len(session.calls) == 1
+
+    def test_request_exception_retries_then_returns_none(self, monkeypatch):
+        # Neutralize tenacity's fixed 2s wait so the 3 attempts run instantly.
+        monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+        err = kce.requests.exceptions.ConnectionError("connection reset")
+        session = _patch_session(monkeypatch, _FakeSession(err))
+        result = kce.scrape_url("https://bookwalker.jp/series/123")
+        # After 3 failed attempts the retry_error_callback returns None.
+        assert result is None
+        assert len(session.calls) == 3
+
+    def test_passes_headers_when_provided(self, monkeypatch):
+        session = _patch_session(monkeypatch, _FakeSession(_FakeResp(200, b"<html></html>")))
+        kce.scrape_url("https://bookwalker.jp/x", headers={"X-Test": "1"})
+        # None-valued params are filtered out; provided headers are forwarded.
+        assert session.calls[0].get("headers") == {"X-Test": "1"}
+        assert "cookies" not in session.calls[0]

--- a/tests/external/test_discord.py
+++ b/tests/external/test_discord.py
@@ -1,0 +1,90 @@
+"""Characterization tests for the Discord notification layer.
+
+Pins send_discord_message (webhook execution + reset behavior) and
+group_notification (the batching buffer used throughout the pipeline). The
+discord-webhook library is never actually hit: we patch
+``DiscordWebhook.execute`` at the class level (send_discord_message resets the
+global ``webhook_obj`` to a fresh instance after every call, so an instance-level
+patch would be lost — the class-level patch survives).
+"""
+
+import pytest
+
+import komga_cover_extractor as kce
+
+pytestmark = pytest.mark.external
+
+
+def _make_embed(title="t", desc="d"):
+    return kce.Embed(kce.DiscordEmbed(title=title, description=desc), None)
+
+
+class TestSendDiscordMessage:
+    def test_no_webhook_configured_returns_false(self, monkeypatch):
+        # No url, no passed_webhook, empty discord_webhook_url -> pick_webhook
+        # yields None, the body is skipped, sent_status stays False.
+        monkeypatch.setattr(kce, "discord_webhook_url", [])
+        calls = []
+        monkeypatch.setattr(kce.DiscordWebhook, "execute",
+                            lambda self, *a, **k: calls.append(self))
+        assert kce.send_discord_message("hello") is False
+        assert calls == []
+
+    def test_passed_webhook_executes_and_returns_true(self, monkeypatch):
+        executed = []
+        monkeypatch.setattr(
+            kce.DiscordWebhook, "execute",
+            lambda self, *a, **k: executed.append(getattr(self, "content", None)),
+        )
+        result = kce.send_discord_message("hi there", passed_webhook="http://example/wh")
+        assert result is True
+        assert executed == ["hi there"]
+
+    def test_webhook_obj_reset_after_send(self, monkeypatch):
+        monkeypatch.setattr(kce.DiscordWebhook, "execute", lambda self, *a, **k: None)
+        kce.send_discord_message("hi", passed_webhook="http://example/wh")
+        # After every call the global webhook_obj is reset to a fresh url=None object.
+        assert kce.webhook_obj.url is None
+
+    def test_execute_exception_returns_false_and_resets(self, monkeypatch):
+        def _boom(self, *a, **k):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(kce.DiscordWebhook, "execute", _boom)
+        # The exception is swallowed; sent_status False is returned, obj reset.
+        assert kce.send_discord_message("hi", passed_webhook="http://example/wh") is False
+        assert kce.webhook_obj.url is None
+
+
+class TestGroupNotification:
+    def test_appends_embed_to_buffer(self, monkeypatch):
+        monkeypatch.setattr(kce, "discord_embed_limit", 10)
+        embed = _make_embed()
+        out = kce.group_notification([], embed)
+        assert out == [embed]
+        assert len(out) == 1
+
+    def test_does_not_duplicate_same_embed(self, monkeypatch):
+        monkeypatch.setattr(kce, "discord_embed_limit", 10)
+        embed = _make_embed()
+        notifications = kce.group_notification([], embed)
+        # FLAG: dedup is identity-based (`embed not in notifications`); re-passing
+        # the SAME object does not append it again.
+        notifications = kce.group_notification(notifications, embed)
+        assert notifications == [embed]
+
+    def test_flushes_when_at_limit(self, monkeypatch):
+        # When the buffer is already at the embed limit, group_notification flushes
+        # it via send_discord_message before appending the new embed.
+        monkeypatch.setattr(kce, "discord_embed_limit", 1)
+        monkeypatch.setattr(kce, "discord_webhook_url", ["http://example/wh"])
+        sent = []
+        monkeypatch.setattr(kce, "send_discord_message",
+                            lambda *a, **k: (sent.append(a) or True))
+        first = _make_embed("first")
+        buffer = [first]  # len 1 >= limit 1 -> triggers flush
+        second = _make_embed("second")
+        out = kce.group_notification(buffer, second)
+        assert sent, "expected a flush via send_discord_message"
+        # the old buffer was flushed (emptied) and only the new embed remains
+        assert out == [second]

--- a/tests/external/test_komga.py
+++ b/tests/external/test_komga.py
@@ -1,0 +1,109 @@
+"""Characterization tests for the Komga HTTP integration.
+
+Pins get_komga_libraries / scan_komga_library against mocked requests. These use
+``requests.get`` / ``requests.post`` directly (with HTTPBasicAuth + a tenacity
+retry that only fires on a "104" connection-reset), so the conftest
+``mock_requests`` fixture (which patches ``kce.requests.get/post``) covers them.
+
+All tests are marked ``external``: run with ``-m external`` (or together with the
+default suite). Credentials are set on the kce namespace per the project's
+``from settings import *`` convention; the autouse isolated_globals fixture
+restores them.
+"""
+
+import pytest
+
+import komga_cover_extractor as kce
+
+pytestmark = pytest.mark.external
+
+
+def _set_creds(monkeypatch):
+    monkeypatch.setattr(kce, "komga_ip", "http://localhost")
+    monkeypatch.setattr(kce, "komga_port", "25600")
+    monkeypatch.setattr(kce, "komga_login_email", "user@example.com")
+    monkeypatch.setattr(kce, "komga_login_password", "secret")
+
+
+# --------------------------------------------------------------------------- #
+# get_komga_libraries
+# --------------------------------------------------------------------------- #
+
+class TestGetKomgaLibraries:
+    def test_missing_ip_returns_none_no_request(self, monkeypatch, mock_requests):
+        # FLAG: a guard-failure (missing ip/email/password) returns None — NOT the
+        # empty list `results`. Callers must handle the None vs [] distinction.
+        monkeypatch.setattr(kce, "komga_ip", "")
+        assert kce.get_komga_libraries() is None
+        assert mock_requests.get_calls == []
+
+    def test_missing_email_returns_none(self, monkeypatch, mock_requests):
+        monkeypatch.setattr(kce, "komga_ip", "http://localhost")
+        monkeypatch.setattr(kce, "komga_login_email", "")
+        assert kce.get_komga_libraries() is None
+
+    def test_missing_password_returns_none(self, monkeypatch, mock_requests):
+        monkeypatch.setattr(kce, "komga_ip", "http://localhost")
+        monkeypatch.setattr(kce, "komga_login_email", "user@example.com")
+        monkeypatch.setattr(kce, "komga_login_password", "")
+        assert kce.get_komga_libraries() is None
+
+    def test_200_returns_json_payload(self, monkeypatch, mock_requests, fake_response):
+        _set_creds(monkeypatch)
+        payload = [{"id": "lib1", "name": "Manga"}, {"id": "lib2", "name": "Novels"}]
+        mock_requests.get_returns(fake_response(status_code=200, json_data=payload))
+        assert kce.get_komga_libraries() == payload
+
+    def test_200_uses_port_in_url(self, monkeypatch, mock_requests, fake_response):
+        _set_creds(monkeypatch)
+        mock_requests.get_returns(fake_response(status_code=200, json_data=[]))
+        kce.get_komga_libraries()
+        # url is the first positional arg to requests.get
+        (args, kwargs) = mock_requests.get_calls[0]
+        url = args[0] if args else kwargs.get("url")
+        assert url == "http://localhost:25600/api/v1/libraries"
+
+    def test_non_200_returns_empty_list(self, monkeypatch, mock_requests, fake_response):
+        # FLAG: a non-200 response leaves `results` as the initial [] and returns it,
+        # so a server error is indistinguishable from "no libraries" at the call site.
+        _set_creds(monkeypatch)
+        mock_requests.get_returns(fake_response(status_code=500, text="boom"))
+        assert kce.get_komga_libraries() == []
+
+    def test_no_port_uses_bare_ip(self, monkeypatch, mock_requests, fake_response):
+        monkeypatch.setattr(kce, "komga_ip", "http://localhost")
+        monkeypatch.setattr(kce, "komga_port", "")
+        monkeypatch.setattr(kce, "komga_login_email", "user@example.com")
+        monkeypatch.setattr(kce, "komga_login_password", "secret")
+        mock_requests.get_returns(fake_response(status_code=200, json_data=[]))
+        kce.get_komga_libraries()
+        (args, kwargs) = mock_requests.get_calls[0]
+        url = args[0] if args else kwargs.get("url")
+        assert url == "http://localhost/api/v1/libraries"
+
+
+# --------------------------------------------------------------------------- #
+# scan_komga_library
+# --------------------------------------------------------------------------- #
+
+class TestScanKomgaLibrary:
+    def test_missing_ip_returns_none_no_request(self, monkeypatch, mock_requests):
+        monkeypatch.setattr(kce, "komga_ip", "")
+        assert kce.scan_komga_library("lib1", "Manga") is None
+        assert mock_requests.post_calls == []
+
+    def test_202_posts_scan_url(self, monkeypatch, mock_requests, fake_response):
+        _set_creds(monkeypatch)
+        mock_requests.post_returns(fake_response(status_code=202))
+        # returns None regardless; the observable is the POST to the scan endpoint
+        assert kce.scan_komga_library("lib1", "Manga") is None
+        (args, kwargs) = mock_requests.post_calls[0]
+        url = args[0] if args else kwargs.get("url")
+        assert url == "http://localhost:25600/api/v1/libraries/lib1/scan"
+
+    def test_non_202_does_not_raise(self, monkeypatch, mock_requests, fake_response):
+        _set_creds(monkeypatch)
+        mock_requests.post_returns(fake_response(status_code=500, text="nope"))
+        # error path logs via send_message but does not raise
+        assert kce.scan_komga_library("lib1", "Manga") is None
+        assert len(mock_requests.post_calls) == 1

--- a/tests/fs/test_file_ops.py
+++ b/tests/fs/test_file_ops.py
@@ -1,0 +1,712 @@
+"""Characterization tests for file-operation helpers in komga_cover_extractor.py.
+
+Functions under test
+--------------------
+  move_file, remove_file, rename_file, replace_file,
+  set_modification_date, get_lines_from_file, write_to_file
+
+Design notes
+------------
+* All assertions pin what the code does TODAY — behaviour is pinned AS-IS.
+* FLAG: comments mark surprising or potentially buggy behaviour.
+* Every test operates entirely under tmp_path; the real library is never touched.
+* grouped_notifications side-effects are verified by snapshotting
+  ``len(kce.grouped_notifications)`` before/after each call.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_file_obj(tmp_dir: str, filename: str, volume_number: int = 1) -> kce.File:
+    """Build a real on-disk file and return a matching kce.File instance."""
+    path = os.path.join(tmp_dir, filename)
+    open(path, "w").close()
+    return kce.File(
+        name=filename,
+        extensionless_name=kce.get_extensionless_name(filename),
+        basename=os.path.splitext(filename)[0],
+        extension=kce.get_file_extension(filename),
+        root=tmp_dir,
+        path=path,
+        extensionless_path=kce.get_extensionless_name(path),
+        volume_number=volume_number,
+        file_type="volume",
+        header_extension=None,
+    )
+
+
+def _make_file_obj_no_disk(tmp_dir: str, filename: str) -> kce.File:
+    """Build a kce.File instance for a path that does NOT exist on disk."""
+    path = os.path.join(tmp_dir, filename)
+    return kce.File(
+        name=filename,
+        extensionless_name=kce.get_extensionless_name(filename),
+        basename=os.path.splitext(filename)[0],
+        extension=kce.get_file_extension(filename),
+        root=tmp_dir,
+        path=path,
+        extensionless_path=kce.get_extensionless_name(path),
+        volume_number=1,
+        file_type="volume",
+        header_extension=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# move_file
+# ---------------------------------------------------------------------------
+
+class TestMoveFile:
+    """Pin move_file(file, new_location, silent=False, ...) behaviour."""
+
+    def test_moves_file_to_destination(self, tmp_path, monkeypatch):
+        """File is present at destination and absent at source after a successful move."""
+        src_dir = str(tmp_path / "src")
+        dst_dir = str(tmp_path / "dst")
+        os.makedirs(src_dir)
+        os.makedirs(dst_dir)
+        f = _make_file_obj(src_dir, "Series v01.cbz")
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.move_file(f, dst_dir, silent=True)
+
+        assert result is True
+        assert not os.path.isfile(os.path.join(src_dir, "Series v01.cbz"))
+        assert os.path.isfile(os.path.join(dst_dir, "Series v01.cbz"))
+
+    def test_returns_true_on_success(self, tmp_path, monkeypatch):
+        """Return value is exactly True (bool) on a successful move."""
+        src_dir = str(tmp_path / "src")
+        dst_dir = str(tmp_path / "dst")
+        os.makedirs(src_dir)
+        os.makedirs(dst_dir)
+        f = _make_file_obj(src_dir, "Series v01.cbz")
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.move_file(f, dst_dir, silent=True)
+
+        assert result is True
+        assert type(result) is bool
+
+    def test_silent_true_does_not_grow_notifications(self, tmp_path, monkeypatch):
+        """silent=True: grouped_notifications length is unchanged."""
+        src_dir = str(tmp_path / "src")
+        dst_dir = str(tmp_path / "dst")
+        os.makedirs(src_dir)
+        os.makedirs(dst_dir)
+        f = _make_file_obj(src_dir, "Series v01.cbz")
+
+        notifs = []
+        monkeypatch.setattr(kce, "grouped_notifications", notifs)
+        before = len(kce.grouped_notifications)
+        kce.move_file(f, dst_dir, silent=True)
+        assert len(kce.grouped_notifications) - before == 0
+
+    def test_silent_false_grows_notifications_by_one(self, tmp_path, monkeypatch):
+        """silent=False: grouped_notifications grows by exactly 1."""
+        src_dir = str(tmp_path / "src")
+        dst_dir = str(tmp_path / "dst")
+        os.makedirs(src_dir)
+        os.makedirs(dst_dir)
+        f = _make_file_obj(src_dir, "Series v01.cbz")
+
+        notifs = []
+        monkeypatch.setattr(kce, "grouped_notifications", notifs)
+        before = len(kce.grouped_notifications)
+        kce.move_file(f, dst_dir, silent=False)
+        assert len(kce.grouped_notifications) - before == 1
+
+    def test_nonexistent_source_returns_none(self, tmp_path, monkeypatch):
+        """If the source file does not exist on disk, move_file returns None.
+
+        FLAG: returns None (not False) because the outer try-block falls through
+        without hitting a return statement when os.path.isfile(file.path) is False.
+        """
+        dst_dir = str(tmp_path / "dst")
+        os.makedirs(dst_dir)
+        f = _make_file_obj_no_disk(str(tmp_path), "NotExist.cbz")
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.move_file(f, dst_dir, silent=True)
+
+        # FLAG: returns None, not False, when source does not exist.
+        assert result is None
+
+    def test_conflict_at_destination_returns_false(self, tmp_path, monkeypatch):
+        """If a file with the same name already exists at destination, move fails.
+
+        shutil.move raises OSError on macOS/Python 3.13 when destination exists;
+        the except clause returns False.
+        """
+        src_dir = str(tmp_path / "src")
+        dst_dir = str(tmp_path / "dst")
+        os.makedirs(src_dir)
+        os.makedirs(dst_dir)
+        f = _make_file_obj(src_dir, "Series v01.cbz")
+        # Pre-create the file at destination to trigger the conflict
+        open(os.path.join(dst_dir, "Series v01.cbz"), "w").close()
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.move_file(f, dst_dir, silent=True)
+
+        assert result is False
+
+    def test_moves_associated_image_alongside_file(self, tmp_path, monkeypatch):
+        """move_images() is called after a successful move, carrying the sidecar image."""
+        src_dir = str(tmp_path / "src")
+        dst_dir = str(tmp_path / "dst")
+        os.makedirs(src_dir)
+        os.makedirs(dst_dir)
+
+        cbz_path = os.path.join(src_dir, "Series v01.cbz")
+        jpg_path = os.path.join(src_dir, "Series v01.jpg")  # sidecar
+        open(cbz_path, "w").close()
+        open(jpg_path, "w").close()
+
+        f = kce.File(
+            name="Series v01.cbz",
+            extensionless_name="Series v01",
+            basename="Series",
+            extension=".cbz",
+            root=src_dir,
+            path=cbz_path,
+            extensionless_path=os.path.join(src_dir, "Series v01"),
+            volume_number=1,
+            file_type="volume",
+            header_extension=None,
+        )
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.move_file(f, dst_dir, silent=True)
+
+        assert result is True
+        assert os.path.isfile(os.path.join(dst_dir, "Series v01.cbz"))
+        assert os.path.isfile(os.path.join(dst_dir, "Series v01.jpg"))
+        assert not os.path.isfile(jpg_path)
+
+
+# ---------------------------------------------------------------------------
+# remove_file
+# ---------------------------------------------------------------------------
+
+class TestRemoveFile:
+    """Pin remove_file(full_file_path, silent=False) behaviour."""
+
+    def test_removes_existing_file(self, tmp_path):
+        """A file that exists on disk is deleted; returns True."""
+        p = tmp_path / "testfile.cbz"
+        p.write_text("")
+        result = kce.remove_file(str(p), silent=True)
+
+        assert result is True
+        assert type(result) is bool
+        assert not p.exists()
+
+    def test_silent_true_does_not_grow_notifications(self, tmp_path, monkeypatch):
+        """silent=True: grouped_notifications length is unchanged."""
+        p = tmp_path / "testfile.cbz"
+        p.write_text("")
+
+        notifs = []
+        monkeypatch.setattr(kce, "grouped_notifications", notifs)
+        before = len(kce.grouped_notifications)
+        kce.remove_file(str(p), silent=True)
+        assert len(kce.grouped_notifications) - before == 0
+
+    def test_silent_false_grows_notifications_by_one(self, tmp_path, monkeypatch):
+        """silent=False: grouped_notifications grows by exactly 1."""
+        p = tmp_path / "testfile.cbz"
+        p.write_text("")
+
+        notifs = []
+        monkeypatch.setattr(kce, "grouped_notifications", notifs)
+        before = len(kce.grouped_notifications)
+        kce.remove_file(str(p), silent=False)
+        assert len(kce.grouped_notifications) - before == 1
+
+    def test_nonexistent_file_returns_false(self, tmp_path, monkeypatch):
+        """remove_file returns False when the target path does not exist."""
+        p = tmp_path / "notexist.cbz"
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.remove_file(str(p), silent=True)
+
+        assert result is False
+
+    def test_removes_associated_sidecar_image(self, tmp_path, monkeypatch):
+        """Removing a non-image file also removes its associated volume cover image."""
+        cbz = tmp_path / "Series v01.cbz"
+        jpg = tmp_path / "Series v01.jpg"
+        cbz.write_text("")
+        jpg.write_text("")
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.remove_file(str(cbz), silent=True)
+
+        assert result is True
+        assert not cbz.exists()
+        assert not jpg.exists()
+
+    def test_removing_image_file_does_not_recurse(self, tmp_path, monkeypatch):
+        """Removing an image file itself returns True and doesn't recurse."""
+        img = tmp_path / "cover.jpg"
+        img.write_text("")
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.remove_file(str(img), silent=True)
+
+        assert result is True
+        assert not img.exists()
+
+
+# ---------------------------------------------------------------------------
+# rename_file
+# ---------------------------------------------------------------------------
+
+class TestRenameFile:
+    """Pin rename_file(src, dest, silent=False) behaviour."""
+
+    def test_renames_file_on_disk(self, tmp_path):
+        """File is absent at src and present at dest after successful rename."""
+        src = tmp_path / "Old v01.cbz"
+        dst = tmp_path / "New v01.cbz"
+        src.write_text("")
+
+        result = kce.rename_file(str(src), str(dst), silent=True)
+
+        assert result is True
+        assert not src.exists()
+        assert dst.exists()
+
+    def test_returns_bool_true_on_success(self, tmp_path):
+        """Return type is exactly bool, value True."""
+        src = tmp_path / "A v01.cbz"
+        dst = tmp_path / "B v01.cbz"
+        src.write_text("")
+
+        result = kce.rename_file(str(src), str(dst), silent=True)
+
+        assert type(result) is bool
+        assert result is True
+
+    def test_returns_false_when_src_absent(self, tmp_path):
+        """rename_file returns False when src does not exist (file not touched)."""
+        src = tmp_path / "NotExist.cbz"
+        dst = tmp_path / "Whatever.cbz"
+
+        result = kce.rename_file(str(src), str(dst), silent=True)
+
+        assert result is False
+
+    def test_never_modifies_grouped_notifications_silent_false(self, tmp_path, monkeypatch):
+        """rename_file NEVER adds to grouped_notifications even with silent=False.
+
+        FLAG: rename_file uses send_message(..., discord=False) — it only prints to
+        stdout and never creates a Discord embed, so grouped_notifications stays
+        unchanged regardless of the silent flag.
+        """
+        src = tmp_path / "Old v01.cbz"
+        dst = tmp_path / "New v01.cbz"
+        src.write_text("")
+
+        notifs = []
+        monkeypatch.setattr(kce, "grouped_notifications", notifs)
+        before = len(kce.grouped_notifications)
+        kce.rename_file(str(src), str(dst), silent=False)
+        after = len(kce.grouped_notifications)
+
+        # FLAG: grouped_notifications delta is 0 even when silent=False.
+        assert after - before == 0
+
+    def test_never_modifies_grouped_notifications_silent_true(self, tmp_path, monkeypatch):
+        """silent=True also leaves grouped_notifications unchanged."""
+        src = tmp_path / "Old v01.cbz"
+        dst = tmp_path / "New v01.cbz"
+        src.write_text("")
+
+        notifs = []
+        monkeypatch.setattr(kce, "grouped_notifications", notifs)
+        before = len(kce.grouped_notifications)
+        kce.rename_file(str(src), str(dst), silent=True)
+        after = len(kce.grouped_notifications)
+
+        assert after - before == 0
+
+    def test_cascades_cover_image_rename_jpg(self, tmp_path):
+        """Renaming a cbz also renames its sidecar .jpg cover image.
+
+        FLAG: cover-image cascade — renaming 'X.cbz' to 'Y.cbz' recursively
+        calls rename_file('X.jpg', 'Y.jpg', silent=True) for every image extension
+        that exists on disk. This is an in-place side-effect of the rename.
+        """
+        src_cbz = tmp_path / "Old v01.cbz"
+        src_jpg = tmp_path / "Old v01.jpg"
+        dst_cbz = tmp_path / "New v01.cbz"
+        dst_jpg = tmp_path / "New v01.jpg"
+
+        src_cbz.write_text("")
+        src_jpg.write_text("")
+
+        result = kce.rename_file(str(src_cbz), str(dst_cbz), silent=True)
+
+        assert result is True
+        assert not src_cbz.exists()
+        assert dst_cbz.exists()
+        assert not src_jpg.exists()    # FLAG: cascade renamed old sidecar away
+        assert dst_jpg.exists()        # FLAG: cascade created renamed sidecar
+
+    def test_cascades_cover_image_rename_multiple_extensions(self, tmp_path):
+        """Cover cascade fires for every image extension that exists on disk."""
+        src_cbz = tmp_path / "Old v01.cbz"
+        src_cbz.write_text("")
+        src_imgs = {}
+        for ext in (".jpg", ".png", ".webp"):
+            p = tmp_path / f"Old v01{ext}"
+            p.write_text("")
+            src_imgs[ext] = p
+
+        result = kce.rename_file(str(src_cbz), str(tmp_path / "New v01.cbz"), silent=True)
+
+        assert result is True
+        for ext in (".jpg", ".png", ".webp"):
+            assert not src_imgs[ext].exists(), f"src sidecar {ext} should be gone"
+            assert (tmp_path / f"New v01{ext}").exists(), f"dst sidecar {ext} should exist"
+
+    def test_no_cascade_when_renaming_image_file(self, tmp_path):
+        """Renaming an image file itself does NOT trigger the cascade recursion."""
+        src = tmp_path / "cover.jpg"
+        dst = tmp_path / "new_cover.jpg"
+        src.write_text("")
+
+        result = kce.rename_file(str(src), str(dst), silent=True)
+
+        assert result is True
+        assert not src.exists()
+        assert dst.exists()
+
+    def test_cascade_skips_non_existent_image_extensions(self, tmp_path):
+        """Cascade only renames image files that actually exist; others are silently skipped."""
+        src_cbz = tmp_path / "Old v01.cbz"
+        dst_cbz = tmp_path / "New v01.cbz"
+        src_cbz.write_text("")
+        # Only create .jpg sidecar; .png, .webp, etc. are absent
+
+        result = kce.rename_file(str(src_cbz), str(dst_cbz), silent=True)
+
+        assert result is True
+        # No .png or .webp sidecar was created at destination
+        for ext in (".png", ".webp", ".tbn", ".jpeg"):
+            assert not (tmp_path / f"New v01{ext}").exists()
+
+
+# ---------------------------------------------------------------------------
+# replace_file
+# ---------------------------------------------------------------------------
+
+class TestReplaceFile:
+    """Pin replace_file(old_file, new_file, highest_index_num='') behaviour."""
+
+    def _make_pair(self, tmp_path, old_name="Old v01.cbz", new_name="New v01.cbz"):
+        old_dir = str(tmp_path / "old_dir")
+        new_dir = str(tmp_path / "new_dir")
+        os.makedirs(old_dir)
+        os.makedirs(new_dir)
+        old_file = _make_file_obj(old_dir, old_name)
+        new_file = _make_file_obj(new_dir, new_name)
+        return old_dir, new_dir, old_file, new_file
+
+    def test_replace_moves_new_to_old_dir(self, tmp_path, monkeypatch):
+        """After replace_file, new_file ends up in old_file's directory."""
+        old_dir, new_dir, old_file, new_file = self._make_pair(tmp_path)
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.replace_file(old_file, new_file)
+
+        assert result is True
+        assert os.path.isfile(os.path.join(old_dir, new_file.name))
+
+    def test_replace_removes_old_file(self, tmp_path, monkeypatch):
+        """replace_file removes the old file from its original location."""
+        old_dir, new_dir, old_file, new_file = self._make_pair(tmp_path)
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        kce.replace_file(old_file, new_file)
+
+        assert not os.path.isfile(old_file.path)
+
+    def test_returns_true_on_success(self, tmp_path, monkeypatch):
+        """Return type is exactly bool, value True on a successful replace."""
+        old_dir, new_dir, old_file, new_file = self._make_pair(tmp_path)
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.replace_file(old_file, new_file)
+
+        assert type(result) is bool
+        assert result is True
+
+    def test_grows_notifications_by_two(self, tmp_path, monkeypatch):
+        """replace_file adds exactly 2 notifications: one from remove_file, one from itself.
+
+        Breakdown:
+          * remove_file(old_file.path) — called without silent=True → +1
+          * replace_file itself appends its own 'Moved File' embed → +1
+        Total delta = 2.
+        """
+        old_dir, new_dir, old_file, new_file = self._make_pair(tmp_path)
+
+        notifs = []
+        monkeypatch.setattr(kce, "grouped_notifications", notifs)
+        before = len(kce.grouped_notifications)
+        kce.replace_file(old_file, new_file)
+        after = len(kce.grouped_notifications)
+
+        assert after - before == 2
+
+    def test_returns_false_when_old_file_missing(self, tmp_path, monkeypatch):
+        """If old_file doesn't exist on disk, replace_file returns False without touching anything."""
+        old_dir = str(tmp_path / "old_dir")
+        new_dir = str(tmp_path / "new_dir")
+        os.makedirs(old_dir)
+        os.makedirs(new_dir)
+
+        # old_file path doesn't exist
+        old_file = _make_file_obj_no_disk(old_dir, "Old v01.cbz")
+        new_file = _make_file_obj(new_dir, "New v01.cbz")
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.replace_file(old_file, new_file)
+
+        assert result is False
+
+    def test_returns_false_when_new_file_missing(self, tmp_path, monkeypatch):
+        """If new_file doesn't exist on disk, replace_file returns False."""
+        old_dir = str(tmp_path / "old_dir")
+        new_dir = str(tmp_path / "new_dir")
+        os.makedirs(old_dir)
+        os.makedirs(new_dir)
+
+        old_file = _make_file_obj(old_dir, "Old v01.cbz")
+        new_file = _make_file_obj_no_disk(new_dir, "New v01.cbz")
+
+        monkeypatch.setattr(kce, "grouped_notifications", [])
+        result = kce.replace_file(old_file, new_file)
+
+        assert result is False
+
+    def test_returns_false_no_notifications_on_missing_file(self, tmp_path, monkeypatch):
+        """On file-missing failure, grouped_notifications does not grow."""
+        old_dir = str(tmp_path / "old_dir")
+        new_dir = str(tmp_path / "new_dir")
+        os.makedirs(old_dir)
+        os.makedirs(new_dir)
+
+        old_file = _make_file_obj_no_disk(old_dir, "Old v01.cbz")
+        new_file = _make_file_obj(new_dir, "New v01.cbz")
+
+        notifs = []
+        monkeypatch.setattr(kce, "grouped_notifications", notifs)
+        before = len(kce.grouped_notifications)
+        kce.replace_file(old_file, new_file)
+        after = len(kce.grouped_notifications)
+
+        assert after - before == 0
+
+
+# ---------------------------------------------------------------------------
+# set_modification_date
+# ---------------------------------------------------------------------------
+
+class TestSetModificationDate:
+    """Pin set_modification_date(file_path, date) behaviour."""
+
+    def test_sets_mtime_to_given_value(self, tmp_path):
+        """mtime is set to the provided timestamp."""
+        p = tmp_path / "test.cbz"
+        p.write_text("")
+        target = 946684800.0  # 2000-01-01 00:00:00 UTC
+
+        kce.set_modification_date(str(p), target)
+
+        assert kce.get_modification_date(str(p)) == target
+
+    def test_preserves_atime_as_original_mtime(self, tmp_path):
+        """atime is set to the file's mtime at call time (reads via get_modification_date).
+
+        FLAG: atime is set to the *original mtime* of the file (not the current
+        access time), because os.utime is called with
+        (get_modification_date(file_path), date) — i.e. atime := old mtime.
+        """
+        p = tmp_path / "test.cbz"
+        p.write_text("")
+        original_mtime = kce.get_modification_date(str(p))
+        target = 946684800.0
+
+        kce.set_modification_date(str(p), target)
+
+        st = os.stat(str(p))
+        assert st.st_atime == original_mtime  # FLAG: atime = old mtime
+        assert st.st_mtime == target
+
+    def test_returns_none(self, tmp_path):
+        """set_modification_date has no return value (returns None)."""
+        p = tmp_path / "test.cbz"
+        p.write_text("")
+        result = kce.set_modification_date(str(p), 946684800.0)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_lines_from_file
+# ---------------------------------------------------------------------------
+
+class TestGetLinesFromFile:
+    """Pin get_lines_from_file(file_path, ignore=[], check_paths=False) behaviour."""
+
+    def test_reads_lines_stripped(self, tmp_path):
+        """Lines are stripped of surrounding whitespace."""
+        p = tmp_path / "test.txt"
+        p.write_text("  line1  \nline2\n  line3\n")
+        result = kce.get_lines_from_file(str(p))
+        assert result == ["line1", "line2", "line3"]
+        assert type(result) is list
+
+    def test_skips_blank_and_whitespace_only_lines(self, tmp_path):
+        """Blank lines and lines that are entirely whitespace are omitted."""
+        p = tmp_path / "test.txt"
+        p.write_text("line1\n\n   \nline2\n")
+        result = kce.get_lines_from_file(str(p))
+        assert result == ["line1", "line2"]
+
+    def test_deduplicates_lines(self, tmp_path):
+        """Duplicate lines appear only once in the result."""
+        p = tmp_path / "test.txt"
+        p.write_text("line1\nline1\nline2\n")
+        result = kce.get_lines_from_file(str(p))
+        assert result == ["line1", "line2"]
+
+    def test_ignore_param_excludes_matching_lines(self, tmp_path):
+        """Lines that appear in the ignore list are excluded from results."""
+        p = tmp_path / "test.txt"
+        p.write_text("line1\nline2\nline3\n")
+        result = kce.get_lines_from_file(str(p), ignore=["line1"])
+        assert result == ["line2", "line3"]
+
+    def test_nonexistent_file_returns_empty_list(self, tmp_path):
+        """When the file does not exist, returns an empty list (not an exception)."""
+        result = kce.get_lines_from_file(str(tmp_path / "notexist.txt"))
+        assert result == []
+        assert type(result) is list
+
+    def test_check_paths_filters_by_kce_paths(self, tmp_path, monkeypatch):
+        """check_paths=True: only lines starting with a prefix in kce.paths are kept."""
+        p = tmp_path / "test.txt"
+        p.write_text("/allowed/file1\n/blocked/file2\n/allowed/file3\n")
+        monkeypatch.setattr(kce, "paths", ["/allowed"])
+        result = kce.get_lines_from_file(str(p), check_paths=True)
+        assert result == ["/allowed/file1", "/allowed/file3"]
+
+    def test_check_paths_no_filter_when_paths_empty(self, tmp_path, monkeypatch):
+        """check_paths=True with kce.paths=[] performs no path filtering."""
+        p = tmp_path / "test.txt"
+        p.write_text("/allowed/file1\n/blocked/file2\n")
+        monkeypatch.setattr(kce, "paths", [])
+        result = kce.get_lines_from_file(str(p), check_paths=True)
+        assert result == ["/allowed/file1", "/blocked/file2"]
+
+    def test_returns_list_of_strings(self, tmp_path):
+        """Every element in the result is a str."""
+        p = tmp_path / "test.txt"
+        p.write_text("alpha\nbeta\n")
+        result = kce.get_lines_from_file(str(p))
+        assert all(isinstance(line, str) for line in result)
+
+
+# ---------------------------------------------------------------------------
+# write_to_file
+# ---------------------------------------------------------------------------
+
+class TestWriteToFile:
+    """Pin write_to_file(file, message, ...) behaviour."""
+
+    def test_creates_log_file_and_returns_true(self, tmp_path):
+        """On first write, creates the log file and returns True."""
+        result = kce.write_to_file(
+            "run.log", "hello", without_timestamp=True, write_to=str(tmp_path), can_write_log=True
+        )
+        assert result is True
+        assert type(result) is bool
+        assert (tmp_path / "run.log").exists()
+
+    def test_without_timestamp_writes_message_only(self, tmp_path):
+        """without_timestamp=True writes the message prefixed by a newline, no date."""
+        kce.write_to_file(
+            "run.log", "hello world", without_timestamp=True, write_to=str(tmp_path), can_write_log=True
+        )
+        content = (tmp_path / "run.log").read_text()
+        assert content == "\nhello world"
+
+    def test_with_timestamp_includes_date_prefix(self, tmp_path):
+        """without_timestamp=False (default) prepends a dd/mm/YYYY HH:MM:SS string."""
+        import re
+        kce.write_to_file(
+            "run.log", "msg", without_timestamp=False, write_to=str(tmp_path), can_write_log=True
+        )
+        content = (tmp_path / "run.log").read_text()
+        # Timestamp format: \nDD/MM/YYYY HH:MM:SS msg
+        assert re.match(r"\n\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2} msg", content)
+
+    def test_appends_on_second_write(self, tmp_path):
+        """Subsequent writes (without overwrite=True) append to the existing file."""
+        kce.write_to_file("run.log", "first", without_timestamp=True, write_to=str(tmp_path), can_write_log=True)
+        kce.write_to_file("run.log", "second", without_timestamp=True, write_to=str(tmp_path), can_write_log=True)
+        content = (tmp_path / "run.log").read_text()
+        assert content == "\nfirst\nsecond"
+
+    def test_overwrite_truncates_file(self, tmp_path):
+        """overwrite=True replaces any existing content."""
+        kce.write_to_file("run.log", "original", without_timestamp=True, write_to=str(tmp_path), can_write_log=True)
+        kce.write_to_file("run.log", "overwritten", without_timestamp=True, write_to=str(tmp_path), can_write_log=True, overwrite=True)
+        content = (tmp_path / "run.log").read_text()
+        assert content == "\noverwritten"
+
+    def test_can_write_log_false_returns_false(self, tmp_path):
+        """can_write_log=False short-circuits: returns False, no file created."""
+        result = kce.write_to_file(
+            "run.log", "hello", write_to=str(tmp_path), can_write_log=False
+        )
+        assert result is False
+        assert not (tmp_path / "run.log").exists()
+
+    def test_check_for_dup_prevents_duplicate_message(self, tmp_path):
+        """check_for_dup=True: writing the same message a second time returns False and does not append."""
+        kce.write_to_file("run.log", "dupe", without_timestamp=True, write_to=str(tmp_path), can_write_log=True)
+        r2 = kce.write_to_file("run.log", "dupe", without_timestamp=True, write_to=str(tmp_path), can_write_log=True, check_for_dup=True)
+        content = (tmp_path / "run.log").read_text()
+        assert r2 is False
+        assert content == "\ndupe"  # written only once
+
+    def test_strips_tab_and_newline_from_message(self, tmp_path):
+        """Tabs and newlines in the message are stripped before writing."""
+        kce.write_to_file("run.log", "  he\tllo\nworld  ", without_timestamp=True, write_to=str(tmp_path), can_write_log=True)
+        content = (tmp_path / "run.log").read_text()
+        assert content == "\nhelloworld"
+
+    def test_creates_write_to_directory_if_absent(self, tmp_path):
+        """write_to_file creates the logs directory if it does not exist."""
+        logs_dir = str(tmp_path / "newlogs" / "subdir")
+        result = kce.write_to_file(
+            "run.log", "hello", without_timestamp=True, write_to=logs_dir, can_write_log=True
+        )
+        assert result is True
+        assert os.path.isfile(os.path.join(logs_dir, "run.log"))

--- a/tests/fs/test_scanning.py
+++ b/tests/fs/test_scanning.py
@@ -1,0 +1,614 @@
+"""Characterization tests for directory-scanning helpers.
+
+Functions covered:
+  - get_all_folders_recursively_in_dir
+  - get_all_files_in_directory
+  - cache_existing_library_paths
+  - clean_and_sort
+
+All tests pin CURRENT behaviour including surprising / buggy aspects flagged
+with ``# FLAG:`` comments. Nothing is "fixed" here — see CLAUDE.md rationale.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _isolate(monkeypatch):
+    """Pin the three globals that affect scanning behaviour."""
+    monkeypatch.setattr(kce, "paths", [])
+    monkeypatch.setattr(kce, "download_folders", [])
+    monkeypatch.setattr(kce, "cached_paths", [])
+    monkeypatch.setattr(kce, "log_to_file", False)
+
+
+# =========================================================================== #
+# get_all_folders_recursively_in_dir
+# =========================================================================== #
+
+class TestGetAllFoldersRecursively:
+    """Pin structure and content of get_all_folders_recursively_in_dir."""
+
+    def test_returns_list_of_dicts(self, tmp_path, monkeypatch):
+        """Return value is a plain list of dicts."""
+        _isolate(monkeypatch)
+        root = tmp_path / "library"
+        root.mkdir()
+        result = kce.get_all_folders_recursively_in_dir(str(root))
+        assert isinstance(result, list)
+        assert all(isinstance(item, dict) for item in result)
+
+    def test_dict_keys(self, tmp_path, monkeypatch):
+        """Each dict has exactly the keys 'root', 'dirs', 'files'."""
+        _isolate(monkeypatch)
+        root = tmp_path / "library"
+        root.mkdir()
+        result = kce.get_all_folders_recursively_in_dir(str(root))
+        assert len(result) >= 1
+        for item in result:
+            assert set(item.keys()) == {"root", "dirs", "files"}
+
+    def test_empty_directory_one_entry(self, tmp_path, monkeypatch):
+        """A single empty directory yields exactly one entry."""
+        _isolate(monkeypatch)
+        root = tmp_path / "empty"
+        root.mkdir()
+        result = kce.get_all_folders_recursively_in_dir(str(root))
+        assert len(result) == 1
+        assert result[0]["root"] == str(root)
+        assert result[0]["dirs"] == []
+        assert result[0]["files"] == []
+
+    def test_tree_with_one_subdir_yields_two_entries(self, tmp_path, monkeypatch):
+        """root + 1 subdir yields 2 walk entries."""
+        _isolate(monkeypatch)
+        root = tmp_path / "library"
+        sub = root / "Test Series"
+        sub.mkdir(parents=True)
+        (sub / "v01.cbz").write_bytes(b"")
+
+        result = kce.get_all_folders_recursively_in_dir(str(root))
+        roots = [item["root"] for item in result]
+        assert len(result) == 2
+        assert str(root) in roots
+        assert str(sub) in roots
+
+    def test_root_entry_lists_subdirs(self, tmp_path, monkeypatch):
+        """The root-level entry's 'dirs' list contains the subdir name."""
+        _isolate(monkeypatch)
+        root = tmp_path / "library"
+        sub = root / "Series A"
+        sub.mkdir(parents=True)
+
+        result = kce.get_all_folders_recursively_in_dir(str(root))
+        root_entry = next(e for e in result if e["root"] == str(root))
+        assert "Series A" in root_entry["dirs"]
+
+    def test_files_in_subdir_entry(self, tmp_path, monkeypatch):
+        """Files under a subdir appear in that entry's 'files' list."""
+        _isolate(monkeypatch)
+        root = tmp_path / "library"
+        sub = root / "Series A"
+        sub.mkdir(parents=True)
+        (sub / "Series A v01.cbz").write_bytes(b"")
+        (sub / "Series A v02.cbz").write_bytes(b"")
+
+        result = kce.get_all_folders_recursively_in_dir(str(root))
+        sub_entry = next(e for e in result if e["root"] == str(sub))
+        assert set(sub_entry["files"]) == {"Series A v01.cbz", "Series A v02.cbz"}
+
+    def test_no_extension_filtering_done_here(self, tmp_path, monkeypatch):
+        """get_all_folders_recursively_in_dir does NOT filter by extension."""
+        _isolate(monkeypatch)
+        root = tmp_path / "library"
+        sub = root / "Series"
+        sub.mkdir(parents=True)
+        (sub / "a.cbz").write_bytes(b"")
+        (sub / ".hidden.cbz").write_bytes(b"")
+        (sub / "readme.txt").write_bytes(b"")
+
+        result = kce.get_all_folders_recursively_in_dir(str(root))
+        sub_entry = next(e for e in result if e["root"] == str(sub))
+        # All files are present — no hidden or extension filtering
+        assert ".hidden.cbz" in sub_entry["files"]
+        assert "readme.txt" in sub_entry["files"]
+
+    def test_root_in_paths_is_skipped(self, tmp_path, monkeypatch):
+        """A walk entry whose 'root' is in kce.paths is skipped."""
+        _isolate(monkeypatch)
+        root = tmp_path / "library"
+        sub1 = root / "Series A"
+        sub2 = root / "Series B"
+        sub1.mkdir(parents=True)
+        sub2.mkdir(parents=True)
+
+        monkeypatch.setattr(kce, "paths", [str(sub1)])
+        result = kce.get_all_folders_recursively_in_dir(str(root))
+        returned_roots = {e["root"] for e in result}
+        # sub1 is in kce.paths → skipped
+        assert str(sub1) not in returned_roots
+        # root and sub2 are returned
+        assert str(root) in returned_roots
+        assert str(sub2) in returned_roots
+
+    def test_root_in_download_folders_is_skipped(self, tmp_path, monkeypatch):
+        """A walk entry whose 'root' is in kce.download_folders is skipped."""
+        _isolate(monkeypatch)
+        root = tmp_path / "library"
+        sub1 = root / "Series A"
+        sub2 = root / "Series B"
+        sub1.mkdir(parents=True)
+        sub2.mkdir(parents=True)
+
+        monkeypatch.setattr(kce, "download_folders", [str(sub2)])
+        result = kce.get_all_folders_recursively_in_dir(str(root))
+        returned_roots = {e["root"] for e in result}
+        assert str(sub2) not in returned_roots
+        assert str(root) in returned_roots
+        assert str(sub1) in returned_roots
+
+    def test_files_at_root_level_appear_in_root_entry(self, tmp_path, monkeypatch):
+        """Files placed directly in the scan root appear in the root entry."""
+        _isolate(monkeypatch)
+        root = tmp_path / "library"
+        root.mkdir()
+        (root / "stray.cbz").write_bytes(b"")
+
+        result = kce.get_all_folders_recursively_in_dir(str(root))
+        root_entry = next(e for e in result if e["root"] == str(root))
+        assert "stray.cbz" in root_entry["files"]
+
+
+# =========================================================================== #
+# get_all_files_in_directory
+# =========================================================================== #
+
+class TestGetAllFilesInDirectory:
+    """Pin behaviour of get_all_files_in_directory."""
+
+    def test_returns_list(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        result = kce.get_all_files_in_directory(str(tmp_path))
+        assert isinstance(result, list)
+
+    def test_returns_basenames_not_full_paths(self, tmp_path, monkeypatch):
+        """Returned items are bare filenames, not absolute or relative paths."""
+        _isolate(monkeypatch)
+        sub = tmp_path / "Series"
+        sub.mkdir()
+        (sub / "v01.cbz").write_bytes(b"")
+
+        result = kce.get_all_files_in_directory(str(tmp_path))
+        assert len(result) == 1
+        assert result[0] == "v01.cbz"
+        assert os.sep not in result[0]
+
+    def test_extension_filter_keeps_accepted_types(self, tmp_path, monkeypatch):
+        """Only files with kce.file_extensions (.epub, .zip, .cbz) are kept."""
+        _isolate(monkeypatch)
+        sub = tmp_path / "Series"
+        sub.mkdir()
+        (sub / "v01.cbz").write_bytes(b"")
+        (sub / "v02.epub").write_bytes(b"")
+        (sub / "v03.zip").write_bytes(b"")
+
+        result = kce.get_all_files_in_directory(str(tmp_path))
+        assert set(result) == {"v01.cbz", "v02.epub", "v03.zip"}
+
+    def test_hidden_files_excluded(self, tmp_path, monkeypatch):
+        """Files starting with '.' (dot-files) are filtered out."""
+        _isolate(monkeypatch)
+        sub = tmp_path / "Series"
+        sub.mkdir()
+        (sub / ".hidden.cbz").write_bytes(b"")
+        (sub / "v01.cbz").write_bytes(b"")
+
+        result = kce.get_all_files_in_directory(str(tmp_path))
+        assert ".hidden.cbz" not in result
+        assert "v01.cbz" in result
+
+    def test_unaccepted_extensions_excluded(self, tmp_path, monkeypatch):
+        """Files with .txt, .jpg, .png extensions are excluded."""
+        _isolate(monkeypatch)
+        sub = tmp_path / "Series"
+        sub.mkdir()
+        (sub / "readme.txt").write_bytes(b"")
+        (sub / "cover.jpg").write_bytes(b"")
+        (sub / "v01.cbz").write_bytes(b"")
+
+        result = kce.get_all_files_in_directory(str(tmp_path))
+        assert "readme.txt" not in result
+        assert "cover.jpg" not in result
+        assert "v01.cbz" in result
+
+    def test_recurses_into_subdirectories(self, tmp_path, monkeypatch):
+        """Files in nested subdirectories are collected."""
+        _isolate(monkeypatch)
+        sub1 = tmp_path / "Series A"
+        sub2 = tmp_path / "Series B"
+        sub1.mkdir()
+        sub2.mkdir()
+        (sub1 / "a_v01.cbz").write_bytes(b"")
+        (sub2 / "b_v01.cbz").write_bytes(b"")
+
+        result = kce.get_all_files_in_directory(str(tmp_path))
+        assert set(result) == {"a_v01.cbz", "b_v01.cbz"}
+
+    def test_empty_directory_returns_empty_list(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        result = kce.get_all_files_in_directory(str(tmp_path))
+        assert result == []
+
+
+# =========================================================================== #
+# cache_existing_library_paths
+# =========================================================================== #
+
+class TestCacheExistingLibraryPaths:
+    """Pin the side-effects and return value of cache_existing_library_paths."""
+
+    def test_returns_list(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        root = tmp_path / "lib"
+        root.mkdir()
+        monkeypatch.setattr(kce, "paths", [str(root)])
+
+        result = kce.cache_existing_library_paths(
+            paths=[str(root)], download_folders=[], cached_paths=kce.cached_paths
+        )
+        assert isinstance(result, list)
+
+    def test_return_value_is_same_object_as_kce_cached_paths(self, tmp_path, monkeypatch):
+        """Return value IS the kce.cached_paths list object (not a copy)."""
+        _isolate(monkeypatch)
+        root = tmp_path / "lib"
+        (root / "Series A").mkdir(parents=True)
+        monkeypatch.setattr(kce, "paths", [str(root)])
+
+        before_id = id(kce.cached_paths)
+        result = kce.cache_existing_library_paths(
+            paths=[str(root)], download_folders=[], cached_paths=kce.cached_paths
+        )
+        # FLAG: return value is the same list object passed in AND kce.cached_paths
+        assert result is kce.cached_paths
+        assert id(result) == before_id
+
+    def test_subdirectories_added_to_cached_paths(self, tmp_path, monkeypatch):
+        """Subdirectories under the root path are appended to kce.cached_paths."""
+        _isolate(monkeypatch)
+        root = tmp_path / "lib"
+        sub_a = root / "Series A"
+        sub_b = root / "Series B"
+        sub_a.mkdir(parents=True)
+        sub_b.mkdir(parents=True)
+        monkeypatch.setattr(kce, "paths", [str(root)])
+
+        kce.cache_existing_library_paths(
+            paths=[str(root)], download_folders=[], cached_paths=kce.cached_paths
+        )
+        assert str(sub_a) in kce.cached_paths
+        assert str(sub_b) in kce.cached_paths
+
+    def test_root_itself_not_added_to_cached_paths(self, tmp_path, monkeypatch):
+        """The scanned root path itself is NOT added to cached_paths."""
+        _isolate(monkeypatch)
+        root = tmp_path / "lib"
+        (root / "Series A").mkdir(parents=True)
+        monkeypatch.setattr(kce, "paths", [str(root)])
+
+        kce.cache_existing_library_paths(
+            paths=[str(root)], download_folders=[], cached_paths=kce.cached_paths
+        )
+        # root is in kce.paths so cache_path skips it
+        assert str(root) not in kce.cached_paths
+
+    def test_nested_subdirectories_also_cached(self, tmp_path, monkeypatch):
+        """Nested subdirectories (depth > 1) are also cached."""
+        _isolate(monkeypatch)
+        root = tmp_path / "lib"
+        nested = root / "Series A" / "Volume Extra"
+        nested.mkdir(parents=True)
+        monkeypatch.setattr(kce, "paths", [str(root)])
+
+        kce.cache_existing_library_paths(
+            paths=[str(root)], download_folders=[], cached_paths=kce.cached_paths
+        )
+        assert str(nested) in kce.cached_paths
+        assert str(nested.parent) in kce.cached_paths
+
+    def test_path_in_download_folders_is_skipped(self, tmp_path, monkeypatch):
+        """A path that is also in download_folders is skipped entirely."""
+        _isolate(monkeypatch)
+        root = tmp_path / "lib"
+        (root / "Series A").mkdir(parents=True)
+        monkeypatch.setattr(kce, "paths", [str(root)])
+
+        kce.cache_existing_library_paths(
+            paths=[str(root)],
+            download_folders=[str(root)],
+            cached_paths=kce.cached_paths,
+        )
+        assert kce.cached_paths == []
+
+    def test_nonexistent_path_does_not_raise(self, monkeypatch):
+        """A nonexistent path is silently skipped; cached_paths stays empty."""
+        _isolate(monkeypatch)
+        result = kce.cache_existing_library_paths(
+            paths=["/nonexistent/__kce_test__"],
+            download_folders=[],
+            cached_paths=kce.cached_paths,
+        )
+        assert result == []
+        assert kce.cached_paths == []
+
+    def test_already_cached_path_not_duplicated(self, tmp_path, monkeypatch):
+        """A subdirectory that is already in cached_paths is not re-added."""
+        _isolate(monkeypatch)
+        root = tmp_path / "lib"
+        sub = root / "Series A"
+        sub.mkdir(parents=True)
+        monkeypatch.setattr(kce, "paths", [str(root)])
+
+        # Pre-populate cached_paths with the subdir
+        kce.cached_paths.append(str(sub))
+        kce.cache_existing_library_paths(
+            paths=[str(root)], download_folders=[], cached_paths=kce.cached_paths
+        )
+        # Should still be exactly one entry
+        assert kce.cached_paths.count(str(sub)) == 1
+
+    def test_empty_paths_list_returns_empty(self, monkeypatch):
+        _isolate(monkeypatch)
+        result = kce.cache_existing_library_paths(
+            paths=[], download_folders=[], cached_paths=kce.cached_paths
+        )
+        assert result == []
+
+
+# =========================================================================== #
+# clean_and_sort
+# =========================================================================== #
+
+class TestCleanAndSort:
+    """Pin clean_and_sort behaviour including mutation side-effects."""
+
+    # ---- return type ---------------------------------------------------- #
+
+    def test_returns_tuple_of_two_lists(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        result = kce.clean_and_sort(str(tmp_path), files=[], dirs=[], test_mode=True)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        files_out, dirs_out = result
+        assert isinstance(files_out, list)
+        assert isinstance(dirs_out, list)
+
+    def test_empty_inputs_return_empty_lists(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files_out, dirs_out = kce.clean_and_sort(
+            str(tmp_path), files=[], dirs=[], test_mode=True
+        )
+        assert files_out == []
+        assert dirs_out == []
+
+    # ---- hidden file removal -------------------------------------------- #
+
+    def test_hidden_files_removed_by_default(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files = [".hidden.cbz", "visible.cbz"]
+        files_out, _ = kce.clean_and_sort(
+            str(tmp_path), files=files, test_mode=True
+        )
+        assert ".hidden.cbz" not in files_out
+        assert "visible.cbz" in files_out
+
+    def test_skip_remove_hidden_files_keeps_dot_files(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files = [".hidden.cbz", "visible.cbz"]
+        files_out, _ = kce.clean_and_sort(
+            str(tmp_path), files=files, skip_remove_hidden_files=True, test_mode=True
+        )
+        assert ".hidden.cbz" in files_out
+
+    # ---- extension filtering -------------------------------------------- #
+
+    def test_unaccepted_extensions_removed(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files = ["v01.cbz", "readme.txt", "cover.jpg"]
+        files_out, _ = kce.clean_and_sort(
+            str(tmp_path), files=files, test_mode=True
+        )
+        assert "v01.cbz" in files_out
+        assert "readme.txt" not in files_out
+        assert "cover.jpg" not in files_out
+
+    def test_skip_remove_unaccepted_file_types_keeps_all_extensions(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files = ["v01.cbz", "readme.txt"]
+        files_out, _ = kce.clean_and_sort(
+            str(tmp_path), files=files, skip_remove_unaccepted_file_types=True, test_mode=True
+        )
+        assert "readme.txt" in files_out
+        assert "v01.cbz" in files_out
+
+    # ---- sort=True in-place mutation ------------------------------------ #
+
+    def test_sort_true_mutates_input_files_list_in_place(self, tmp_path, monkeypatch):
+        """FLAG: sort=True calls files.sort() on the caller's list object.
+
+        The input list is mutated in-place BEFORE the filtered copy is
+        returned. This is a side-effect that callers may not expect.
+        """
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files = ["c.cbz", "a.cbz", "b.cbz"]
+        original_id = id(files)
+        kce.clean_and_sort(str(tmp_path), files=files, sort=True, test_mode=True)
+        # The list object is the same but its contents are now sorted
+        assert id(files) == original_id
+        assert files == ["a.cbz", "b.cbz", "c.cbz"]  # mutated in-place
+
+    def test_sort_true_mutates_input_dirs_list_in_place(self, tmp_path, monkeypatch):
+        """FLAG: sort=True also calls dirs.sort() on the caller's dirs list."""
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        dirs = ["SeriesC", "SeriesA", "SeriesB"]
+        original_id = id(dirs)
+        kce.clean_and_sort(str(tmp_path), dirs=dirs, sort=True, test_mode=True)
+        assert id(dirs) == original_id
+        assert dirs == ["SeriesA", "SeriesB", "SeriesC"]  # mutated in-place
+
+    def test_sort_false_does_not_mutate_input_list(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files = ["c.cbz", "a.cbz", "b.cbz"]
+        files_copy = list(files)
+        kce.clean_and_sort(str(tmp_path), files=files, sort=False, test_mode=True)
+        assert files == files_copy  # unchanged
+
+    def test_sorted_result_files_is_new_object_not_input_list(self, tmp_path, monkeypatch):
+        """The returned files list is a NEW object (not the sorted input list)."""
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files = ["b.cbz", "a.cbz"]
+        files_out, _ = kce.clean_and_sort(
+            str(tmp_path), files=files, sort=True, test_mode=True
+        )
+        assert files_out is not files
+
+    def test_sort_output_is_sorted(self, tmp_path, monkeypatch):
+        """Returned files are in sorted order when sort=True."""
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files = ["c.cbz", "a.cbz", "b.cbz"]
+        files_out, _ = kce.clean_and_sort(
+            str(tmp_path), files=files, sort=True, test_mode=True
+        )
+        assert files_out == ["a.cbz", "b.cbz", "c.cbz"]
+
+    # ---- hidden folder removal ------------------------------------------ #
+
+    def test_hidden_dirs_removed_by_default(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        dirs = [".hidden", "visible"]
+        _, dirs_out = kce.clean_and_sort(
+            str(tmp_path), dirs=dirs, test_mode=True
+        )
+        assert ".hidden" not in dirs_out
+        assert "visible" in dirs_out
+
+    def test_skip_remove_hidden_folders_keeps_dot_dirs(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        dirs = [".hidden", "visible"]
+        _, dirs_out = kce.clean_and_sort(
+            str(tmp_path), dirs=dirs, skip_remove_hidden_folders=True, test_mode=True
+        )
+        assert ".hidden" in dirs_out
+
+    # ---- ignored_folder_names ------------------------------------------- #
+
+    def test_ignored_folder_in_root_path_returns_empty_tuple(self, tmp_path, monkeypatch):
+        """If root path contains an ignored folder segment, returns ([], [])."""
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", ["_ignore"])
+
+        bad_root = tmp_path / "_ignore" / "subdir"
+        bad_root.mkdir(parents=True)
+        result = kce.clean_and_sort(
+            str(bad_root), files=["v01.cbz"], test_mode=True
+        )
+        assert result == ([], [])
+
+    def test_ignored_folder_names_removed_from_dirs(self, tmp_path, monkeypatch):
+        """Dirs matching ignored_folder_names are removed from the dirs list."""
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", ["_ignore"])
+        dirs = ["_ignore", "good"]
+        _, dirs_out = kce.clean_and_sort(
+            str(tmp_path), dirs=dirs, test_mode=True
+        )
+        assert "_ignore" not in dirs_out
+        assert "good" in dirs_out
+
+    def test_skip_remove_ignored_folders_keeps_ignored_dirs(self, tmp_path, monkeypatch):
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", ["_ignore"])
+        dirs = ["_ignore", "good"]
+        _, dirs_out = kce.clean_and_sort(
+            str(tmp_path), dirs=dirs, skip_remove_ignored_folders=True, test_mode=True
+        )
+        assert "_ignore" in dirs_out
+
+    # ---- chapters toggle ------------------------------------------------ #
+
+    def test_chapters_false_filters_chapter_only_files(self, tmp_path, monkeypatch):
+        """When chapters=False, chapter-only releases are filtered out."""
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files = ["Series ch001.cbz", "Series v01.cbz"]
+        files_out, _ = kce.clean_and_sort(
+            str(tmp_path), files=files, chapters=False, test_mode=True
+        )
+        assert "Series ch001.cbz" not in files_out
+        assert "Series v01.cbz" in files_out
+
+    def test_chapters_true_keeps_chapter_files(self, tmp_path, monkeypatch):
+        """When chapters=True, chapter files are kept."""
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        files = ["Series ch001.cbz", "Series v01.cbz"]
+        files_out, _ = kce.clean_and_sort(
+            str(tmp_path), files=files, chapters=True, test_mode=True
+        )
+        assert "Series ch001.cbz" in files_out
+        assert "Series v01.cbz" in files_out
+
+    # ---- just_these_files ------------------------------------------------ #
+
+    def test_just_these_files_filters_to_specified_files(self, tmp_path, monkeypatch):
+        """When just_these_files is given, only matching full paths are kept."""
+        _isolate(monkeypatch)
+        monkeypatch.setattr(kce, "check_for_existing_series_toggle", False)
+        monkeypatch.setattr(kce, "ignored_folder_names", [])
+        root = str(tmp_path)
+        files = ["a.cbz", "b.cbz", "c.cbz"]
+        just = [os.path.join(root, "a.cbz")]
+        files_out, _ = kce.clean_and_sort(
+            root, files=files, just_these_files=just, test_mode=True
+        )
+        assert files_out == ["a.cbz"]

--- a/tests/fs/test_sorting.py
+++ b/tests/fs/test_sorting.py
@@ -1,0 +1,558 @@
+"""Characterization tests for get_sort_key-based sorting and organize_by_first_letter.
+
+Every assertion was verified against the live module BEFORE writing:
+    .venv/bin/python -c "import komga_cover_extractor as kce; print(repr(kce.FUNC(ARGS)))"
+
+Surprising / buggy behavior is noted with a ``# FLAG:`` comment and pinned AS-IS.
+
+Functions covered (all from komga_cover_extractor.py):
+    get_sort_key, sort_volumes, organize_by_first_letter
+
+Volume objects are built using the production pipeline:
+    upgrade_to_file_class(..., test_mode=True) + upgrade_to_volume_class(..., test_mode=True)
+These functions are called with real .cbz files written under tmp_path; test_mode=True
+skips the file-header read and forces skip_release_year / skip_publisher / skip_premium_content.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import zipfile
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_cbz(directory: str, name: str) -> str:
+    """Write a minimal zip under *directory* and return just the filename."""
+    path = os.path.join(directory, name)
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("page_001.jpg", b"\xff\xd8\xff\xd9")  # tiny JPEG stub
+    return name
+
+
+def _build_volumes(tmp_path, filenames):
+    """Return list of kce.Volume objects built from *filenames* in *tmp_path*."""
+    d = str(tmp_path)
+    for name in filenames:
+        path = os.path.join(d, name)
+        if not os.path.exists(path):
+            with zipfile.ZipFile(path, "w") as zf:
+                zf.writestr("page_001.jpg", b"\xff\xd8\xff\xd9")
+    files = kce.upgrade_to_file_class(list(filenames), d, test_mode=True)
+    return kce.upgrade_to_volume_class(files, test_mode=True)
+
+
+# ===========================================================================
+# get_sort_key — raw scalar / list inputs
+# ===========================================================================
+
+class TestGetSortKeyScalars:
+    """get_sort_key returns the input unchanged when it is not a list."""
+
+    def test_int_1(self):
+        result = kce.get_sort_key(1)
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_int_2(self):
+        result = kce.get_sort_key(2)
+        assert result == 2
+
+    def test_int_10(self):
+        result = kce.get_sort_key(10)
+        assert result == 10
+
+    def test_float_1_5(self):
+        result = kce.get_sort_key(1.5)
+        assert result == 1.5
+        assert isinstance(result, float)
+
+    def test_int_zero(self):
+        assert kce.get_sort_key(0) == 0
+
+    def test_negative_int(self):
+        assert kce.get_sort_key(-1) == -1
+
+    def test_empty_string_passthrough(self):
+        # FLAG: empty-string index_number passes through unchanged — calling code
+        # must guard against comparing '' with numbers in sort contexts.
+        result = kce.get_sort_key("")
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_numeric_string_passthrough(self):
+        # Strings are NOT parsed to numbers; '1' -> '1'
+        result = kce.get_sort_key("1")
+        assert result == "1"
+        assert isinstance(result, str)
+
+
+class TestGetSortKeyList:
+    """get_sort_key returns min(list) when the input is a list (multi-volume)."""
+
+    def test_ascending_list_returns_first(self):
+        # [1, 2] -> min is 1
+        result = kce.get_sort_key([1, 2])
+        assert result == 1
+
+    def test_descending_list_returns_min(self):
+        # [5, 2] -> min is 2 (not first element)
+        result = kce.get_sort_key([5, 2])
+        assert result == 2
+
+    def test_unsorted_list_returns_min(self):
+        # [10, 1] -> min is 1
+        result = kce.get_sort_key([10, 1])
+        assert result == 1
+
+    def test_equal_elements_list(self):
+        result = kce.get_sort_key([3, 3])
+        assert result == 3
+
+    def test_three_element_list_returns_min(self):
+        result = kce.get_sort_key([2, 5, 8])
+        assert result == 2
+
+    def test_single_element_list(self):
+        result = kce.get_sort_key([7])
+        assert result == 7
+
+
+# ===========================================================================
+# Volume index_number assignment — via upgrade pipeline (test_mode=True)
+# ===========================================================================
+
+class TestVolumeIndexNumbers:
+    """Verify that the upgrade pipeline sets index_number correctly on Volumes."""
+
+    def test_v01_index_is_int_1(self, tmp_path):
+        vols = _build_volumes(tmp_path, ["Series v01.cbz"])
+        assert vols[0].index_number == 1
+        assert isinstance(vols[0].index_number, int)
+
+    def test_v02_index_is_int_2(self, tmp_path):
+        vols = _build_volumes(tmp_path, ["Series v02.cbz"])
+        assert vols[0].index_number == 2
+
+    def test_v10_index_is_int_10(self, tmp_path):
+        vols = _build_volumes(tmp_path, ["Series v10.cbz"])
+        assert vols[0].index_number == 10
+
+    def test_v01_5_index_is_float_1_5(self, tmp_path):
+        vols = _build_volumes(tmp_path, ["Series v01.5.cbz"])
+        assert vols[0].index_number == 1.5
+        assert isinstance(vols[0].index_number, float)
+
+    def test_multi_volume_index_is_list(self, tmp_path):
+        vols = _build_volumes(tmp_path, ["Series v01-02.cbz"])
+        assert vols[0].index_number == [1, 2]
+        assert isinstance(vols[0].index_number, list)
+
+    def test_multi_volume_v05_06_index_is_list(self, tmp_path):
+        vols = _build_volumes(tmp_path, ["Series v05-06.cbz"])
+        assert vols[0].index_number == [5, 6]
+
+
+# ===========================================================================
+# sort_volumes — numeric ordering
+# ===========================================================================
+
+class TestSortVolumesNumeric:
+    """sort_volumes uses get_sort_key(index_number) for all-numeric index sets."""
+
+    def test_natural_numeric_order(self, tmp_path):
+        # v01, v02, v10 in forward order
+        vols = _build_volumes(tmp_path, ["Series v01.cbz", "Series v02.cbz", "Series v10.cbz"])
+        result = kce.sort_volumes(vols)
+        assert [v.name for v in result] == [
+            "Series v01.cbz",
+            "Series v02.cbz",
+            "Series v10.cbz",
+        ]
+
+    def test_reverse_input_still_numeric_order(self, tmp_path):
+        # Providing reverse order input must yield ascending numeric output
+        vols = _build_volumes(tmp_path, ["Series v10.cbz", "Series v02.cbz", "Series v01.cbz"])
+        result = kce.sort_volumes(vols)
+        assert [v.name for v in result] == [
+            "Series v01.cbz",
+            "Series v02.cbz",
+            "Series v10.cbz",
+        ]
+
+    def test_fractional_volume_sorted_between_integers(self, tmp_path):
+        # v01.5 should land between v01 and v02
+        vols = _build_volumes(
+            tmp_path,
+            ["Series v02.cbz", "Series v01.5.cbz", "Series v01.cbz"],
+        )
+        result = kce.sort_volumes(vols)
+        assert [v.name for v in result] == [
+            "Series v01.cbz",
+            "Series v01.5.cbz",
+            "Series v02.cbz",
+        ]
+
+    def test_multi_volume_sorted_by_min_index(self, tmp_path):
+        # v01-02 has min=1, v03 has index=3; so v01-02 comes first
+        vols = _build_volumes(tmp_path, ["Series v03.cbz", "Series v01-02.cbz"])
+        result = kce.sort_volumes(vols)
+        assert result[0].name == "Series v01-02.cbz"
+        assert result[1].name == "Series v03.cbz"
+
+    def test_mixed_single_and_multi_volume(self, tmp_path):
+        # v01-02 (min=1), v01 (index=1), v03 (index=3), v05-06 (min=5)
+        vols = _build_volumes(
+            tmp_path,
+            ["Series v05-06.cbz", "Series v01.cbz", "Series v03.cbz", "Series v01-02.cbz"],
+        )
+        result = kce.sort_volumes(vols)
+        names = [v.name for v in result]
+        # v01.cbz and v01-02.cbz both have sort_key=1; v03 has 3; v05-06 has 5
+        assert names.index("Series v03.cbz") > names.index("Series v01.cbz")
+        assert names.index("Series v05-06.cbz") > names.index("Series v03.cbz")
+
+    def test_empty_list_returns_empty(self):
+        result = kce.sort_volumes([])
+        assert result == []
+
+    def test_single_volume_list_unchanged(self, tmp_path):
+        vols = _build_volumes(tmp_path, ["Series v07.cbz"])
+        result = kce.sort_volumes(vols)
+        assert len(result) == 1
+        assert result[0].name == "Series v07.cbz"
+
+
+class TestSortVolumesAlphabetic:
+    """sort_volumes falls back to alphabetical-by-name when any index is a string."""
+
+    def test_string_index_sorts_alphabetically_by_name(self):
+        # Directly construct Volumes with string index_numbers to trigger the
+        # alphabetic branch (any(isinstance(item.index_number, str) for item in volumes))
+        def _make_vol(name, index_str):
+            return kce.Volume(
+                "volume", name, name, None,
+                "", "", index_str, "",
+                name, name, name, ".cbz",
+                "/tmp", f"/tmp/{name}", f"/tmp/{name}",
+                [], "", False, None, None,
+            )
+
+        vol_z = _make_vol("Z Series.cbz", " ")
+        vol_a = _make_vol("A Series.cbz", " ")
+        vol_m = _make_vol("M Series.cbz", " ")
+
+        result = kce.sort_volumes([vol_z, vol_m, vol_a])
+        assert [v.name for v in result] == ["A Series.cbz", "M Series.cbz", "Z Series.cbz"]
+
+    def test_one_string_index_triggers_alphabetic_branch(self):
+        # If even ONE volume has a string index, the whole list is sorted by name.
+        def _make_vol(name, index):
+            return kce.Volume(
+                "volume", name, name, None,
+                "", "", index, "",
+                name, name, name, ".cbz",
+                "/tmp", f"/tmp/{name}", f"/tmp/{name}",
+                [], "", False, None, None,
+            )
+
+        vol_num = _make_vol("Z Volume.cbz", 1)      # numeric index
+        vol_str = _make_vol("A Volume.cbz", " ")     # string index
+
+        result = kce.sort_volumes([vol_num, vol_str])
+        # alphabetical: 'A Volume.cbz' < 'Z Volume.cbz'
+        assert [v.name for v in result] == ["A Volume.cbz", "Z Volume.cbz"]
+
+
+# ===========================================================================
+# organize_by_first_letter — complementary cases to the legacy suite
+# ===========================================================================
+
+class TestOrganizeByFirstLetterReturnType:
+    """The function always returns a list (new object, not the input)."""
+
+    def test_returns_a_list(self, tmp_path):
+        a = str(tmp_path / "alpha")
+        os.makedirs(a)
+        result = kce.organize_by_first_letter([a], "a", 0, silent=True)
+        assert isinstance(result, list)
+
+    def test_result_is_not_same_object_as_input(self, tmp_path):
+        a = str(tmp_path / "apple")
+        b = str(tmp_path / "banana")
+        os.makedirs(a); os.makedirs(b)
+        lst = [a, b]
+        result = kce.organize_by_first_letter(lst, "a", 0, silent=True)
+        # FLAG: the function rebinds the local `array_list` var (list-comprehension),
+        # so the returned list is a NEW object even when items_to_move is non-empty.
+        assert result is not lst
+
+    def test_input_list_not_mutated(self, tmp_path):
+        a = str(tmp_path / "apple")
+        b = str(tmp_path / "banana")
+        c = str(tmp_path / "cherry")
+        os.makedirs(a); os.makedirs(b); os.makedirs(c)
+        original = [a, b, c]
+        original_copy = list(original)
+        kce.organize_by_first_letter(original, "a", 1, silent=True)
+        assert original == original_copy  # input is NOT mutated
+
+
+class TestOrganizeByFirstLetterEmptyString:
+    """Empty *string* triggers early return of the input list unchanged."""
+
+    def test_empty_string_returns_input_unchanged(self, tmp_path):
+        a = str(tmp_path / "alpha")
+        b = str(tmp_path / "beta")
+        c = str(tmp_path / "cherry")
+        os.makedirs(a); os.makedirs(b); os.makedirs(c)
+        lst = [a, b, c]
+        result = kce.organize_by_first_letter(lst, "", 1, silent=True)
+        assert result == lst
+
+    def test_empty_string_silent_false_prints_message(self, tmp_path):
+        a = str(tmp_path / "alpha")
+        os.makedirs(a)
+        buf = io.StringIO()
+        sys.stdout = buf
+        try:
+            kce.organize_by_first_letter([a], "", 0, silent=False)
+        finally:
+            sys.stdout = sys.__stdout__
+        output = buf.getvalue()
+        assert "First letter of file name was not found" in output
+
+
+class TestOrganizeByFirstLetterOutOfBounds:
+    """Out-of-bounds *position_to_insert_at* causes early return of unchanged list."""
+
+    def test_position_too_large_returns_unchanged(self, tmp_path):
+        a = str(tmp_path / "alpha")
+        b = str(tmp_path / "beta")
+        os.makedirs(a); os.makedirs(b)
+        lst = [a, b]
+        result = kce.organize_by_first_letter(lst, "a", 10, silent=True)
+        assert result == lst
+
+    def test_negative_position_returns_unchanged(self, tmp_path):
+        a = str(tmp_path / "alpha")
+        b = str(tmp_path / "beta")
+        os.makedirs(a); os.makedirs(b)
+        lst = [a, b]
+        result = kce.organize_by_first_letter(lst, "a", -1, silent=True)
+        assert result == lst
+
+
+class TestOrganizeByFirstLetterMovement:
+    """Core reordering: matching items get inserted at *position_to_insert_at*."""
+
+    def test_single_match_moved_to_position(self, tmp_path):
+        # ['alpha_series','beta_series','alpha_other','gamma_series']
+        # string='a', pos=2 -> alpha_series and alpha_other are 'a'-prefixed.
+        # The item at pos=2 is 'alpha_other', which is excluded from moves
+        # (it's array_list[position_to_insert_at]).
+        # alpha_series matches and is NOT the reference item -> moved.
+        # After removal: [beta_series, alpha_other, gamma_series]
+        # Insert alpha_series at pos 2: [beta_series, alpha_other, alpha_series, gamma_series]
+        # — but the test below just verifies the observed exact result.
+        d = [
+            str(tmp_path / n)
+            for n in ["alpha_series", "beta_series", "alpha_other", "gamma_series"]
+        ]
+        for p in d:
+            os.makedirs(p)
+        result = kce.organize_by_first_letter(list(d), "alpha_new", 2, silent=True)
+        assert [os.path.basename(p) for p in result] == [
+            "beta_series",
+            "alpha_other",
+            "alpha_series",
+            "gamma_series",
+        ]
+
+    def test_match_moved_to_position_0(self, tmp_path):
+        # string='a', pos=0 -> item at pos 0 is 'alpha_series' (skipped as reference)
+        # alpha_other matches 'a' and is not the reference -> moved to pos 0
+        # After removal: [alpha_series, beta_series, gamma_series]
+        # Insert alpha_other at 0: [alpha_other, alpha_series, beta_series, gamma_series]
+        d = [
+            str(tmp_path / n)
+            for n in ["alpha_series", "beta_series", "alpha_other", "gamma_series"]
+        ]
+        for p in d:
+            os.makedirs(p)
+        result = kce.organize_by_first_letter(list(d), "alpha_new", 0, silent=True)
+        assert [os.path.basename(p) for p in result] == [
+            "alpha_other",
+            "alpha_series",
+            "beta_series",
+            "gamma_series",
+        ]
+
+    def test_match_moved_to_last_valid_position(self, tmp_path):
+        # string='a', pos=2 (last valid for 3-item list)
+        d = [
+            str(tmp_path / n)
+            for n in ["alpha_series", "beta_series", "alpha_other"]
+        ]
+        for p in d:
+            os.makedirs(p)
+        result = kce.organize_by_first_letter(list(d), "alpha_new", 2, silent=True)
+        # item at pos 2 = alpha_other (skipped); alpha_series moves
+        assert [os.path.basename(p) for p in result] == [
+            "beta_series",
+            "alpha_other",
+            "alpha_series",
+        ]
+
+    def test_no_match_returns_unchanged(self, tmp_path):
+        d = [
+            str(tmp_path / n)
+            for n in ["alpha_series", "beta_series", "cherry"]
+        ]
+        for p in d:
+            os.makedirs(p)
+        original = list(d)
+        result = kce.organize_by_first_letter(list(d), "d_new", 1, silent=True)
+        assert result == original
+
+    def test_multiple_matching_items_inserted_in_iteration_order(self, tmp_path):
+        # ['delta','alpha1','beta','alpha2','alpha3'], string='a', pos=2
+        # item at pos=2 is 'beta' (reference), skipped
+        # matches: alpha1, alpha2, alpha3 (in that iteration order)
+        # after removal: [delta, beta]
+        # insert alpha3 at 2: [delta, beta, alpha3]
+        # insert alpha2 at 2: [delta, beta, alpha2, alpha3]
+        # insert alpha1 at 2: [delta, beta, alpha1, alpha2, alpha3]
+        d = [
+            str(tmp_path / n)
+            for n in ["delta", "alpha1", "beta", "alpha2", "alpha3"]
+        ]
+        for p in d:
+            os.makedirs(p)
+        result = kce.organize_by_first_letter(list(d), "a_new", 2, silent=True)
+        assert [os.path.basename(p) for p in result] == [
+            "delta",
+            "beta",
+            "alpha3",
+            "alpha2",
+            "alpha1",
+        ]
+
+
+class TestOrganizeByFirstLetterCaseInsensitive:
+    """First-letter matching is case-insensitive (both string and item names)."""
+
+    def test_uppercase_string_matches_lowercase_items(self, tmp_path):
+        d = [
+            str(tmp_path / n)
+            for n in ["alpha_series", "beta_series", "alpha_other", "gamma_series"]
+        ]
+        for p in d:
+            os.makedirs(p)
+        # 'Alpha_new'[0].lower() == 'a' -> same result as lowercase 'a'
+        result = kce.organize_by_first_letter(list(d), "Alpha_new", 0, silent=True)
+        assert [os.path.basename(p) for p in result] == [
+            "alpha_other",
+            "alpha_series",
+            "beta_series",
+            "gamma_series",
+        ]
+
+
+class TestOrganizeByFirstLetterExclude:
+    """The *exclude* parameter prevents that item from being moved."""
+
+    def test_excluded_item_not_moved(self, tmp_path):
+        d = [
+            str(tmp_path / n)
+            for n in ["alpha_series", "beta_series", "alpha_other", "gamma_series"]
+        ]
+        for p in d:
+            os.makedirs(p)
+        # Exclude alpha_series -> only alpha_other is a candidate (and not the pos=0 ref)
+        # pos=0 ref = alpha_series itself (also skipped as reference)
+        # So alpha_other is the only thing moved
+        result = kce.organize_by_first_letter(list(d), "alpha_new", 0, exclude=d[0], silent=True)
+        assert [os.path.basename(p) for p in result] == [
+            "alpha_other",
+            "alpha_series",
+            "beta_series",
+            "gamma_series",
+        ]
+
+    def test_exclude_none_does_not_exclude_anything(self, tmp_path):
+        a = str(tmp_path / "apple")
+        b = str(tmp_path / "banana")
+        c = str(tmp_path / "cherry")
+        os.makedirs(a); os.makedirs(b); os.makedirs(c)
+        # 'cherry', pos=1 (banana is reference), no exclude
+        result = kce.organize_by_first_letter([a, b, c], "c_new", 1, exclude=None, silent=True)
+        assert [os.path.basename(p) for p in result] == ["apple", "cherry", "banana"]
+
+
+class TestOrganizeByFirstLetterReferenceItemSkipped:
+    """The item AT position_to_insert_at is skipped in the matching loop."""
+
+    def test_reference_item_at_pos_0_not_moved(self, tmp_path):
+        # cherry is at pos=0 and is the reference item; cherry2 matches but is moved
+        d = [
+            str(tmp_path / n)
+            for n in ["cherry", "apple", "cherry2"]
+        ]
+        for p in d:
+            os.makedirs(p)
+        result = kce.organize_by_first_letter(list(d), "c_new", 0, exclude=None, silent=True)
+        assert [os.path.basename(p) for p in result] == ["cherry2", "cherry", "apple"]
+
+    def test_reference_item_at_pos_1_skipped(self, tmp_path):
+        # cherry at pos=1 is reference; cherry2 at pos=2 gets moved to pos=1
+        d = [
+            str(tmp_path / n)
+            for n in ["apple", "cherry", "cherry2", "delta"]
+        ]
+        for p in d:
+            os.makedirs(p)
+        result = kce.organize_by_first_letter(list(d), "c_new", 1, exclude=None, silent=True)
+        assert [os.path.basename(p) for p in result] == [
+            "apple",
+            "cherry2",
+            "cherry",
+            "delta",
+        ]
+
+    def test_single_item_list_match_at_pos_0_unchanged(self, tmp_path):
+        # Only item is the reference item -> items_to_move is empty -> unchanged
+        a = str(tmp_path / "apple")
+        os.makedirs(a)
+        result = kce.organize_by_first_letter([a], "a_new", 0, silent=True)
+        assert [os.path.basename(p) for p in result] == ["apple"]
+
+
+class TestOrganizeByFirstLetterGammaCase:
+    """Pin the 'g' first-letter case observed in experiments."""
+
+    def test_gamma_series_moved_to_pos_1(self, tmp_path):
+        # ['alpha_series','beta_series','alpha_other','gamma_series']
+        # string='g', pos=1 -> item at pos=1 is 'beta_series' (reference, no match)
+        # gamma_series matches 'g' -> moved
+        d = [
+            str(tmp_path / n)
+            for n in ["alpha_series", "beta_series", "alpha_other", "gamma_series"]
+        ]
+        for p in d:
+            os.makedirs(p)
+        result = kce.organize_by_first_letter(list(d), "gamma_new", 1, silent=True)
+        assert [os.path.basename(p) for p in result] == [
+            "alpha_series",
+            "gamma_series",
+            "beta_series",
+            "alpha_other",
+        ]

--- a/tests/parsing/test_chapter_cleaning.py
+++ b/tests/parsing/test_chapter_cleaning.py
@@ -1,0 +1,363 @@
+"""Characterization tests for ``kce.chapter_file_name_cleaning``.
+
+All expected values were verified against the live interpreter before being
+written here.  This file intentionally pins CURRENT behaviour (including
+quirks) -- it does NOT assert what would be "correct".
+
+Signature (verified via Serena + inspect):
+    @lru_cache(maxsize=3500)
+    chapter_file_name_cleaning(
+        file_name,
+        chapter_number="",
+        skip=False,
+        regex_matched=False,
+    ) -> str
+
+Key behaviour notes:
+* Trailing parentheses/square brackets at end are removed via ``remove_brackets``
+  (only *trailing* groups -- leading ones are left intact).
+* If ``file_name[0].isdigit()`` and ``regex_matched != 2`` the leading
+  "NNN - " prefix is stripped.
+* Trailing " num -" is stripped only when ``regex_matched != 0`` (i.e. when
+  the value is truthy / non-zero).
+* Season keywords ("Season"/"Sea"/"S") followed by a number at the end are
+  removed -- but the regex leaves a trailing space (see FLAG below).
+* A file_name that reduces to a bare digit (or ``#digit`` or ``digit.digit``)
+  returns ``""`` unless ``skip=True``.
+* Empty string raises ``IndexError`` because the code indexes ``file_name[0]``
+  unconditionally.
+"""
+
+from __future__ import annotations
+
+import pytest
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Convenience alias
+# ---------------------------------------------------------------------------
+
+def clean(file_name: str, **kwargs) -> str:
+    """Thin wrapper that clears lru_cache between tests via the autouse fixture."""
+    return kce.chapter_file_name_cleaning(file_name, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: bracket removal
+# ---------------------------------------------------------------------------
+
+class TestBracketRemoval:
+    """Trailing bracket groups are stripped; leading ones are left alone."""
+
+    def test_trailing_round_brackets_removed(self):
+        """'Series Name (2020)' -> trailing '(2020)' is stripped."""
+        assert clean("Series Name (2020)") == "Series Name"
+
+    def test_trailing_square_brackets_not_removed(self):
+        """remove_brackets only strips trailing *round* bracket groups.
+
+        'Series Name [Volume 1]' – the square-bracket group is NOT removed.
+        """
+        # FLAG: remove_brackets does not strip square-bracket groups at the end.
+        assert clean("Series Name [Volume 1]") == "Series Name [Volume 1]"
+
+    def test_leading_round_brackets_left_intact(self):
+        """'(Scans) Series Name' – leading group is NOT removed."""
+        assert clean("(Scans) Series Name") == "(Scans) Series Name"
+
+    def test_leading_square_brackets_left_intact(self):
+        """'[Group] My Series 001' – leading square-bracket group stays."""
+        assert clean("[Group] My Series 001") == "[Group] My Series 001"
+
+    def test_trailing_unclosed_bracket_dropped(self):
+        """A lone '(' at the very end is dropped via ends_with_starting_bracket."""
+        assert clean("Series Name - Bonus Chapter (") == "Series Name - Bonus Chapter"
+
+    def test_trailing_unclosed_square_bracket_dropped(self):
+        """A lone '[' at the end is also dropped."""
+        assert clean("My Series [") == "My Series"
+
+    def test_multiple_trailing_bracket_groups(self):
+        """Multiple trailing bracket groups are both stripped."""
+        assert clean("001 - Series Name (Group) [2020]") == "Series Name (Group)"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: leading digit + dash stripping
+# ---------------------------------------------------------------------------
+
+class TestLeadingDigitStrip:
+    """When file_name starts with a digit and regex_matched != 2, the leading
+    'NNN - ' or 'NNN.M - ' prefix is removed."""
+
+    def test_simple_leading_number_stripped(self):
+        """'001 - My Series' -> 'My Series'."""
+        assert clean("001 - My Series") == "My Series"
+
+    def test_decimal_leading_number_stripped(self):
+        """'006.3 - Series Name' -> 'Series Name'."""
+        assert clean("006.3 - Series Name") == "Series Name"
+
+    def test_leading_digit_strip_skipped_when_regex_matched_2(self):
+        """regex_matched=2 suppresses the leading-digit strip.
+
+        '006.3 - Series Name' stays as '006.3' (subtitle is then removed
+        by the trailing subtitle rule because '-' is present and name[0] is
+        still a digit at that point).
+        """
+        assert clean("006.3 - Series Name", regex_matched=2) == "006.3"
+
+    def test_leading_digit_strip_runs_when_regex_matched_1(self):
+        """regex_matched=1 still strips the leading digit prefix."""
+        assert clean("007 - James Bond", regex_matched=1) == "James Bond"
+
+    def test_no_leading_digit_untouched(self):
+        """A plain series name with no leading digit is returned as-is."""
+        assert clean("My Manga") == "My Manga"
+
+    def test_double_dash_separator_stripped(self):
+        """'012 -- My Series' leading number+double-dash is removed."""
+        assert clean("012 -- My Series") == "My Series"
+
+    def test_underscore_separator_stripped(self):
+        """'012 __ My Series' leading number+double-underscore is removed."""
+        assert clean("012 __ My Series") == "My Series"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: trailing "num -" removal
+# ---------------------------------------------------------------------------
+
+class TestTrailingNumberDashRemoval:
+    """Trailing 'NNN -' is stripped only when regex_matched != 0.
+
+    When regex_matched is False (the default, which equals 0), the
+    number+dash pattern is NOT applied -- only a bare trailing '-' (with no
+    preceding number) is cleaned.
+    """
+
+    def test_trailing_number_dash_not_stripped_by_default(self):
+        """Default regex_matched=False (==0): 'Series Name 54 -' keeps '54'."""
+        # FLAG: regex_matched=False means 0 which disables the num-dash strip;
+        # only the bare trailing '-' regex runs, which doesn't match the '54 -' form.
+        assert clean("Series Name 54 -") == "Series Name 54"
+
+    def test_trailing_number_dash_stripped_when_regex_matched_1(self):
+        """regex_matched=1 (truthy): '54 -' suffix is fully removed."""
+        assert clean("Series Name 54 -", regex_matched=1) == "Series Name"
+
+    def test_trailing_number_dash_stripped_when_regex_matched_2(self):
+        """regex_matched=2 also strips trailing 'num -'."""
+        assert clean("Series Name 54 -", regex_matched=2) == "Series Name"
+
+    def test_trailing_bare_dash_stripped(self):
+        """A trailing bare '-' (no preceding number) is removed regardless of regex_matched."""
+        assert clean("Series -") == "Series"
+        assert clean("Series -", regex_matched=0) == "Series"
+        assert clean("Series -", regex_matched=1) == "Series"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: digit-only reduction -> empty string
+# ---------------------------------------------------------------------------
+
+class TestDigitOnlyReduction:
+    """Names that reduce to a bare number (or #number) return '' unless skip=True."""
+
+    def test_integer_only_returns_empty(self):
+        """'42' is just a digit -> returns ''."""
+        assert clean("42") == ""
+
+    def test_integer_only_skip_true_returns_as_is(self):
+        """With skip=True the digit-only check is bypassed."""
+        assert clean("42", skip=True) == "42"
+
+    def test_decimal_only_returns_empty(self):
+        """'42.5' is effectively a decimal number -> returns ''."""
+        assert clean("42.5") == ""
+
+    def test_decimal_only_skip_true_returns_as_is(self):
+        """With skip=True, '3.5' is returned unchanged."""
+        assert clean("3.5", skip=True) == "3.5"
+
+    def test_hash_digit_returns_empty(self):
+        """'#42' reduces to a digit after removing '#' -> ''."""
+        assert clean("#42") == ""
+
+    def test_hash_digit_skip_true_returned(self):
+        """'#42' with skip=True is returned as '#42'."""
+        # FLAG: skip=True bypasses BOTH digit checks, returning '#42' as-is
+        # even though '#' is not a real chapter name.
+        assert clean("#42", skip=True) == "#42"
+
+    def test_zero_padded_chapter_number_returns_empty(self):
+        """'#001' is a digit-like token -> ''."""
+        assert clean("#001") == ""
+
+    def test_zero_padded_hash_skip_true(self):
+        """'#001' with skip=True returns '#001'."""
+        assert clean("#001", skip=True) == "#001"
+
+    def test_hash_decimal_returns_empty(self):
+        """'#42.5' -> '' (hash+decimal stripped as digit)."""
+        assert clean("#42.5") == ""
+
+    def test_hash_decimal_skip_true(self):
+        """'#42.5' with skip=True returns '#42.5'."""
+        assert clean("#42.5", skip=True) == "#42.5"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: chapter_number removal
+# ---------------------------------------------------------------------------
+
+class TestChapterNumberRemoval:
+    """When chapter_number is provided and regex_matched is falsy, the
+    chapter number at the end of file_name is stripped."""
+
+    def test_chapter_number_stripped_from_end(self):
+        """'Series Name 001' with chapter_number='1' -> 'Series Name'."""
+        assert clean("Series Name 001", chapter_number="1") == "Series Name"
+
+    def test_chapter_number_zero_padded_stripped(self):
+        """chapter_number='001' also removes the trailing '001'."""
+        assert clean("Series Name 001", chapter_number="001") == "Series Name"
+
+    def test_chapter_number_plain_stripped(self):
+        """'Berserk 42' with chapter_number='42' -> 'Berserk'."""
+        assert clean("Berserk 42", chapter_number="42") == "Berserk"
+
+    def test_chapter_number_not_stripped_when_regex_matched(self):
+        """chapter_number removal is skipped when regex_matched is truthy.
+
+        The chapter_number block runs only when ``not regex_matched``.
+        With regex_matched=1 the trailing '001' is NOT removed.
+        """
+        assert clean("Series Name 001", chapter_number="1", regex_matched=1) == "Series Name 001"
+
+    def test_no_chapter_number_no_change(self):
+        """No chapter_number arg: trailing digit stays if it isn't just a digit."""
+        assert clean("Berserk Volume 42") == "Berserk Volume 42"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: season keyword removal
+# ---------------------------------------------------------------------------
+
+class TestSeasonRemoval:
+    """'Season N', 'Sea N', or 'S N' at end of name (case-insensitive) is stripped."""
+
+    def test_season_keyword_removed(self):
+        """'My Series Season 2' -> 'My Series ' (note trailing space -- see FLAG)."""
+        # FLAG: The season-strip regex does not include a trailing strip(), so a
+        # trailing space is left in the returned string.
+        assert clean("My Series Season 2") == "My Series "
+
+    def test_sea_keyword_removed(self):
+        """'My Series Sea 3' -> 'My Series ' (trailing space quirk applies)."""
+        # FLAG: same trailing-space quirk as Season.
+        assert clean("My Series Sea 3") == "My Series "
+
+    def test_season_no_trailing_digit_not_stripped(self):
+        """Season keyword not at end (no trailing digit) is left alone."""
+        assert clean("My Season Adventures") == "My Season Adventures"
+
+    def test_sea_no_space_not_stripped(self):
+        """'My Series Sea2' (no space before digit) still stripped."""
+        # FLAG: regex matches 'Sea' + optional whitespace + digits, so 'Sea2' also matches.
+        assert clean("My Series Sea2") == "My Series "
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: subtitle stripping for leading-digit names
+# ---------------------------------------------------------------------------
+
+class TestSubtitleStripping:
+    """When file_name starts with a digit AND contains '-' or ':', the
+    subtitle after the separator is removed."""
+
+    def test_dash_subtitle_stripped_leading_digit(self):
+        """'179.1 - Epilogue 01': after leading-digit strip we get 'Epilogue 01'.
+
+        The leading digit strip runs first and removes '179.1 - '.
+        Then subtitle strip does NOT apply (no '-' left, and 'E' is not a digit).
+        """
+        assert clean("179.1 - Epilogue 01") == "Epilogue 01"
+
+    def test_colon_subtitle_stripped(self):
+        """'179.1: Epilogue': after bracket strip + leading digit strip, result is '179.1'.
+
+        Actually: leading-digit strip matches '179.1' + ':' -> no, the pattern needs
+        a dash/underscore separator. So the colon is handled by the subtitle rule.
+        """
+        assert clean("179.1: Epilogue") == "179.1"
+
+    def test_subtitle_stripped_regex_matched_2(self):
+        """With regex_matched=2 the leading-digit strip is skipped; subtitle rule fires instead."""
+        # '179.1 - Epilogue 01' -> no leading-digit strip -> subtitle rule fires
+        # -> removes ' - Epilogue 01' -> '179.1'
+        assert clean("179.1 - Epilogue 01", regex_matched=2) == "179.1"
+
+
+# ---------------------------------------------------------------------------
+# FLAG: empty string raises IndexError
+# ---------------------------------------------------------------------------
+
+class TestEmptyStringRaisesIndexError:
+    """An empty file_name causes an IndexError because the code accesses
+    file_name[0] without a prior length check.
+
+    This is a known bug -- we pin it as-is.
+    """
+
+    def test_empty_string_raises_index_error(self):
+        """'' -> IndexError('string index out of range')."""
+        # FLAG: empty string input is not guarded and raises IndexError.
+        # The lru_cache does NOT cache exceptions, so each call raises anew.
+        with pytest.raises(IndexError):
+            clean("")
+
+    def test_empty_string_raises_on_repeated_call(self):
+        """lru_cache does not cache the exception; second call also raises."""
+        with pytest.raises(IndexError):
+            clean("")
+        with pytest.raises(IndexError):
+            clean("")
+
+
+# ---------------------------------------------------------------------------
+# Miscellaneous / integration-style cases
+# ---------------------------------------------------------------------------
+
+class TestMiscellaneous:
+    """A grab-bag of realistic chapter filenames."""
+
+    def test_plain_series_name_unchanged(self):
+        """A series name with no special tokens is returned unchanged."""
+        assert clean("Attack on Titan - Chapter 139") == "Attack on Titan - Chapter 139"
+
+    def test_series_with_chapter_prefix_unchanged(self):
+        """'v01 ch001 - Series Name' does not start with a bare digit (v01)."""
+        assert clean("v01 ch001 - Series Name") == "v01 ch001 - Series Name"
+
+    def test_whitespace_only_returned_as_is(self):
+        """Whitespace-only strings are returned unchanged (no IndexError)."""
+        assert clean("   ") == "   "
+        assert clean(" ") == " "
+
+    def test_series_name_with_trailing_number_no_chapter(self):
+        """Without chapter_number, trailing digit is NOT removed."""
+        assert clean("Berserk Volume 42") == "Berserk Volume 42"
+
+    def test_realistic_chapter_filename_cleaned(self):
+        """Realistic chapter file: trailing round brackets stripped; square brackets also stripped.
+
+        'Solo Leveling c001 (2020) [Scanlation]' ->
+        remove_brackets strips '(2020)' and then '[Scanlation]' as well.
+        The 'S' prefix is not a digit so no leading-digit strip occurs.
+        """
+        # FLAG: remove_brackets strips BOTH trailing '(2020)' and '[Scanlation]' here,
+        # contrary to the earlier observation for '[Volume 1]'. The difference is that
+        # '[Scanlation]' appears after '(2020)' so the combined trailing sequence is removed.
+        assert clean("Solo Leveling c001 (2020) [Scanlation]") == "Solo Leveling c001"

--- a/tests/parsing/test_get_extras.py
+++ b/tests/parsing/test_get_extras.py
@@ -1,0 +1,399 @@
+"""Characterization tests for ``kce.get_extras``.
+
+Signature (verified via Serena + .venv/bin/python):
+    get_extras(
+        file_name: str,
+        chapter: bool = False,
+        series_name: str = "",
+        subtitle: str = "",
+        extension: str = "",
+    ) -> list[str]
+
+Behaviour contract (pinned as-is):
+
+* Extracts bracketed tags ``(…)`` / ``[…]`` / ``{…}`` from the filename.
+* Strips 4-digit year tags ``(YYYY)`` from results.
+* Strips ``(Premium)`` / ``(J-Novel Club Premium)`` bracket variants, then
+  re-appends as ``(Premium)`` (manga) or ``[Premium]`` (novel) at the FRONT
+  of the returned list.
+* ``(Part N)`` / ``[Part N]`` brackets: when ``chapter=True``, Part brackets
+  are removed from their original position and re-appended at the END (after
+  non-premium items); when ``chapter=False`` the Part tag stays where it was.
+* The modifier format depends on the file extension: ``.epub`` → ``[%s]``
+  (novel_extensions), ``.zip``/``.cbz`` → ``(%s)`` (manga_extensions).
+* ``extension`` kwarg overrides the extension derived from the filename.
+
+FLAG: get_extras raises ``KeyError`` (not ValueError) whenever the resolved
+extension is absent from the internal ``modifiers`` dict AND the filename
+contains "premium" or "part" text that triggers a dict lookup.  Specifically:
+  - No extension in filename AND premium/part present → KeyError('')
+  - Unknown extension (e.g. ``.xyz``) AND premium/part present → KeyError('.xyz')
+Files without "premium" or "part" never touch the modifiers dict so they do
+NOT raise even with an unknown extension.
+
+All values below were verified with:
+    .venv/bin/python -c "import komga_cover_extractor as kce; print(repr(kce.get_extras(...)))"
+on the library-replacements branch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helper alias
+# ---------------------------------------------------------------------------
+
+def gx(file_name: str, **kwargs) -> list:
+    """Thin wrapper to keep call sites concise."""
+    return kce.get_extras(file_name, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Basic bracket extraction (no premium, no part)
+# ---------------------------------------------------------------------------
+
+
+class TestBasicExtraction:
+    """Straightforward tag extraction; no premium or part triggers."""
+
+    def test_no_tags_returns_empty_list(self):
+        """Filename with no bracketed tags → empty list."""
+        assert gx("Series v01.cbz") == []
+
+    def test_empty_filename_returns_empty_list(self):
+        """Empty string filename → empty list (no brackets to find)."""
+        assert gx("") == []
+
+    def test_single_round_bracket_tag(self):
+        """Single ``(Digital)`` tag is returned as-is."""
+        assert gx("Series v01 (Digital).cbz") == ["(Digital)"]
+
+    def test_single_square_bracket_tag(self):
+        """Single ``[Seven Seas]`` tag is returned as-is."""
+        assert gx("Series v01 [Seven Seas].cbz") == ["[Seven Seas]"]
+
+    def test_year_tag_only_is_stripped(self):
+        """``(2021)`` alone → stripped → empty list."""
+        assert gx("Series v01 (2021).cbz") == []
+
+    def test_multiple_year_tags_all_stripped(self):
+        """Multiple year tags ``(2021) (2022)`` are all stripped."""
+        assert gx("Series v01 (2021) (2022) (Digital).cbz") == ["(Digital)"]
+
+    def test_no_extension_no_premium_returns_bracket_list(self):
+        """No extension + no premium/part: bracket list is returned without error.
+
+        FLAG: had any premium/part text been present, this would KeyError('').
+        """
+        assert gx("Series v01 (Digital)") == ["(Digital)"]
+
+    def test_curly_brace_tag_preserved(self):
+        """``{Digital}`` curly-brace tag is returned as-is (not converted)."""
+        assert gx("Series v01 {Digital} {Premium}.cbz") == ["(Premium)", "{Digital}"]
+
+    def test_duplicate_tags_deduped(self):
+        """Duplicate ``(Digital)`` entries are deduplicated."""
+        assert gx("Series v01 (Digital) (Digital) [Premium].cbz") == [
+            "(Premium)",
+            "(Digital)",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# The canonical multi-tag spec example
+# (Digital) [Premium] (2021) [Seven Seas]
+# ---------------------------------------------------------------------------
+
+
+class TestSpecExample:
+    """Pin the exact result for the multi-tag spec example from the task brief."""
+
+    def test_cbz_multi_tag_premium_first_year_stripped(self):
+        """``(Digital) [Premium] (2021) [Seven Seas]`` on a .cbz file.
+
+        Expected ordered list:
+          1. ``(Premium)`` — moved to front (manga modifier)
+          2. ``(Digital)``  — preserved in encounter order
+          3. ``[Seven Seas]`` — preserved in encounter order
+          Year ``(2021)`` is stripped.
+        """
+        result = gx("Series v01 (Digital) [Premium] (2021) [Seven Seas].cbz")
+        assert result == ["(Premium)", "(Digital)", "[Seven Seas]"]
+
+    def test_epub_multi_tag_premium_as_square_bracket(self):
+        """Same tags on a .epub file: Premium becomes ``[Premium]`` (novel modifier)."""
+        result = gx("Series v01 (Digital) [Premium] (2021) [Seven Seas].epub")
+        assert result == ["[Premium]", "(Digital)", "[Seven Seas]"]
+
+    def test_zip_multi_tag_same_as_cbz(self):
+        """Same tags on a .zip file: manga modifier → ``(Premium)``."""
+        result = gx("Series v01 (Digital) [Premium] (2021) [Seven Seas].zip")
+        assert result == ["(Premium)", "(Digital)", "[Seven Seas]"]
+
+    def test_tag_encounter_order_preserved_for_non_premium(self):
+        """When [Seven Seas] appears BEFORE (Digital), that order is kept."""
+        result = gx("Series v01 [Seven Seas] (Digital) [Premium] (2021).cbz")
+        assert result == ["(Premium)", "[Seven Seas]", "(Digital)"]
+
+    def test_extension_kwarg_overrides_file_ext(self):
+        """Passing ``extension='.epub'`` on a .cbz filename uses epub modifier."""
+        result = gx(
+            "Series v01 (Digital) [Premium] (2021) [Seven Seas].cbz",
+            extension=".epub",
+        )
+        assert result == ["[Premium]", "(Digital)", "[Seven Seas]"]
+
+
+# ---------------------------------------------------------------------------
+# Premium handling
+# ---------------------------------------------------------------------------
+
+
+class TestPremiumHandling:
+    """Premium tags are normalised and moved to the front."""
+
+    def test_premium_round_bracket_cbz(self):
+        """``(Premium)`` in a .cbz → ``(Premium)`` at front."""
+        assert gx("Series v01 (Premium).cbz") == ["(Premium)"]
+
+    def test_premium_square_bracket_cbz(self):
+        """``[Premium]`` in a .cbz → normalised to ``(Premium)`` (manga modifier)."""
+        assert gx("Series v01 [Premium].cbz") == ["(Premium)"]
+
+    def test_premium_round_bracket_epub(self):
+        """``(Premium)`` in a .epub → ``[Premium]`` (novel modifier)."""
+        assert gx("Series v01 (Premium).epub") == ["[Premium]"]
+
+    def test_j_novel_club_premium_cbz(self):
+        """``(J-Novel Club Premium)`` bracket is stripped; ``(Premium)`` appended."""
+        result = gx("Series v01 (J-Novel Club Premium) (Digital).cbz")
+        assert result == ["(Premium)", "(Digital)"]
+
+    def test_j_novel_club_premium_epub(self):
+        """``(J-Novel Club Premium)`` in .epub → ``[Premium]`` at front."""
+        result = gx("Series v01 (J-Novel Club Premium) (Digital).epub")
+        assert result == ["[Premium]", "(Digital)"]
+
+    def test_premium_plain_text_no_brackets_cbz(self):
+        """``Premium`` as plain (unbracketed) text still triggers the keyword path."""
+        # FLAG: Premium without brackets in the filename triggers the 'premium in
+        # file_name.lower()' code-path, inserting (Premium) even though it was not
+        # a proper bracket tag. This is pinned as-is.
+        assert gx("Series v01 Premium.cbz") == ["(Premium)"]
+
+    def test_curly_brace_premium_cbz(self):
+        """``{Premium}`` curly-brace variant also triggers the premium keyword path.
+
+        The curly-brace ``{Premium}`` is extracted as a bracket result but is then
+        removed by the premium-pattern filter; the keyword path then inserts
+        ``(Premium)`` (manga modifier) at the front.  ``(Digital)`` is a standard
+        round-bracket tag and appears second.
+        """
+        result = gx("Series v01 {Premium} (Digital).cbz")
+        assert result == ["(Premium)", "(Digital)"]
+
+    def test_curly_brace_non_premium_tag_preserved(self):
+        """``{Digital}`` curly-brace tag is returned as-is (not normalised)."""
+        result = gx("Series v01 {Digital} {Premium}.cbz")
+        assert result == ["(Premium)", "{Digital}"]
+
+    def test_explicit_extension_controls_modifier(self):
+        """extension='.epub' on no-ext filename with premium uses novel modifier."""
+        result = gx("Series v01 (Premium)", extension=".epub")
+        assert result == ["[Premium]"]
+
+    def test_explicit_cbz_extension_on_no_ext_file(self):
+        """extension='.cbz' on no-ext filename with premium uses manga modifier."""
+        result = gx("Series v01 (Premium)", extension=".cbz")
+        assert result == ["(Premium)"]
+
+
+# ---------------------------------------------------------------------------
+# series_name and subtitle removal
+# ---------------------------------------------------------------------------
+
+
+class TestSeriesAndSubtitleRemoval:
+    """series_name and subtitle are word-boundary-removed before tag extraction."""
+
+    def test_series_name_removed_from_file_name(self):
+        """series_name='My Series' causes 'My Series' to be stripped first."""
+        result = gx(
+            "My Series v01 (Digital) [Premium] (2021) [Seven Seas].cbz",
+            series_name="My Series",
+        )
+        assert result == ["(Premium)", "(Digital)", "[Seven Seas]"]
+
+    def test_subtitle_removed(self):
+        """subtitle text is stripped, leaving only remaining bracket tags."""
+        result = gx(
+            "My Series v01 Subtitle Here (Digital) [Premium].cbz",
+            series_name="My Series",
+            subtitle="Subtitle Here",
+        )
+        assert result == ["(Premium)", "(Digital)"]
+
+    def test_series_name_strips_year_too(self):
+        """Year is still stripped after series_name removal."""
+        result = gx(
+            "My Series v01 (Digital) (2021) [Premium].cbz",
+            series_name="My Series",
+        )
+        assert result == ["(Premium)", "(Digital)"]
+
+
+# ---------------------------------------------------------------------------
+# Part handling — non-chapter mode
+# ---------------------------------------------------------------------------
+
+
+class TestPartNonChapterMode:
+    """chapter=False (default): Part brackets stay in their encounter position."""
+
+    def test_part_bracket_preserves_position(self):
+        """``(Part 2)`` at front stays at front in non-chapter mode."""
+        result = gx("Series c001 (Part 2) (Digital).cbz", chapter=False)
+        assert result == ["(Part 2)", "(Digital)"]
+
+    def test_part_free_text_appended_as_manga_modifier(self):
+        """'Part 2' as plain text → ``(Part 2)`` appended at end (manga modifier)."""
+        result = gx("Series v01 Part 2 (Digital).cbz", chapter=False)
+        assert result == ["(Digital)", "(Part 2)"]
+
+    def test_part_free_text_epub_appended_as_novel_modifier(self):
+        """'Part 2' as plain text on .epub → ``[Part 2]`` appended."""
+        result = gx("Series v01 Part 2 (Digital).epub", chapter=False)
+        assert result == ["(Digital)", "[Part 2]"]
+
+    def test_part_hyphen_separator(self):
+        """'Part-2' separator variant → ``(Part-2)`` appended."""
+        result = gx("Series v01 Part-2 (Digital).cbz", chapter=False)
+        assert result == ["(Digital)", "(Part-2)"]
+
+    def test_part_underscore_separator(self):
+        """'Part_2' separator variant → ``(Part_2)`` appended."""
+        result = gx("Series v01 Part_2 (Digital).cbz", chapter=False)
+        assert result == ["(Digital)", "(Part_2)"]
+
+    def test_square_bracket_part_non_chapter_preserved(self):
+        """``[Part 2]`` is preserved AND a plain-text match also appended.
+
+        FLAG: when [Part 2] is in brackets AND 'Part 2' also matches the
+        free-text regex, two Part-related items can appear: the original
+        ``[Part 2]`` bracket AND a new ``(Part 2)`` appended.  Pinned as-is.
+        """
+        result = gx("Series v01 [Part 2] (Digital).cbz", chapter=False)
+        assert result == ["[Part 2]", "(Digital)", "(Part 2)"]
+
+
+# ---------------------------------------------------------------------------
+# Part handling — chapter mode
+# ---------------------------------------------------------------------------
+
+
+class TestPartChapterMode:
+    """chapter=True: bracketed (Part N) is removed then re-appended at the END."""
+
+    def test_chapter_mode_part_bracket_moves_to_end(self):
+        """``(Part 1)`` at front is stripped and re-appended after other tags."""
+        result = gx(
+            "Series c001 (Part 1) (Digital) [Seven Seas].cbz", chapter=True
+        )
+        assert result == ["(Digital)", "[Seven Seas]", "(Part 1)"]
+
+    def test_chapter_mode_part_bracket_at_end_stays_at_end(self):
+        """``(Part 1)`` already at end: removal + re-append keeps it there."""
+        result = gx(
+            "Series c001 (Digital) [Seven Seas] (Part 1).cbz", chapter=True
+        )
+        assert result == ["(Digital)", "[Seven Seas]", "(Part 1)"]
+
+    def test_chapter_mode_part_free_text_appended(self):
+        """Plain-text 'Part 2' in chapter mode → re-appended at end."""
+        result = gx("Series c001 Part 2 (Digital).cbz", chapter=True)
+        assert result == ["(Digital)", "(Part 2)"]
+
+    def test_chapter_mode_epub_part_bracket_appended(self):
+        """chapter=True on .epub: Part bracket removed, re-appended as ``[Part 2]``."""
+        result = gx("Series c001 (Part 2) (Digital).epub", chapter=True)
+        assert result == ["(Digital)", "[Part 2]"]
+
+    def test_chapter_mode_premium_stays_front_part_goes_end(self):
+        """Premium at front, Part at end — ordering: premium, non-premium, Part."""
+        result = gx(
+            "Series c001 (Part 2) (Premium) (Digital).cbz", chapter=True
+        )
+        assert result == ["(Premium)", "(Digital)", "(Part 2)"]
+
+    def test_non_chapter_mode_premium_and_part_bracket_ordering(self):
+        """Non-chapter: premium to front, Part stays in position, Digital after it."""
+        result = gx(
+            "Series c001 (Part 2) (Premium) (Digital).cbz", chapter=False
+        )
+        assert result == ["(Premium)", "(Part 2)", "(Digital)"]
+
+
+# ---------------------------------------------------------------------------
+# FLAG: KeyError on unknown / missing extension when premium or part is present
+# ---------------------------------------------------------------------------
+
+
+class TestKeyErrorOnBadExtension:
+    """Accessing modifiers[extension] raises KeyError for unknown extensions.
+
+    FLAG: this is a latent bug — the function raises KeyError instead of
+    returning a graceful fallback.  Only triggered when the filename contains
+    "premium" or "part" (the only two code paths that look up modifiers[ext]).
+    Files without those keywords never touch the dict and succeed silently.
+    """
+
+    def test_empty_extension_with_premium_raises_key_error(self):
+        """No file extension + premium text → KeyError('').
+
+        The extension resolves to '' via get_file_extension, which is not in
+        the modifiers dict.  Pinned with pytest.raises.
+        """
+        with pytest.raises(KeyError, match="''"):
+            kce.get_extras("Test (Premium)")
+
+    def test_explicit_empty_extension_kwarg_with_premium_raises_key_error(self):
+        """``extension=''`` (falsy) falls back to get_file_extension → KeyError('').
+
+        When extension='' is passed explicitly, it is falsy so the code falls
+        back to ``get_file_extension(file_name)``.  A file with no extension
+        returns '' → KeyError.
+        """
+        with pytest.raises(KeyError):
+            kce.get_extras("Test (Premium)", extension="")
+
+    def test_unknown_extension_xyz_with_premium_raises_key_error(self):
+        """Unknown extension ``.xyz`` + premium → KeyError('.xyz').
+
+        ``.xyz`` is not in file_extensions so it is absent from the modifiers
+        dict.  Pinned as KeyError with the extension as the key.
+        """
+        with pytest.raises(KeyError, match=r"\.xyz"):
+            kce.get_extras("Series v01 (Digital) [Premium].xyz")
+
+    def test_unknown_extension_no_premium_does_not_raise(self):
+        """Unknown extension WITHOUT premium/part in name → no KeyError, returns [].
+
+        FLAG: modifiers dict is built but never accessed when neither 'premium'
+        nor 'part' appears in the filename.  The function silently succeeds.
+        """
+        result = kce.get_extras("Test v01.xyz")
+        assert result == []
+
+    def test_cbr_extension_with_premium_raises_key_error(self):
+        """`.cbr` is not in file_extensions → KeyError('.cbr') when premium present."""
+        with pytest.raises(KeyError):
+            kce.get_extras("Series v01 (Premium).cbr")
+
+    def test_rar_extension_with_premium_raises_key_error(self):
+        """`.rar` is not in file_extensions → KeyError('.rar') when premium present."""
+        with pytest.raises(KeyError):
+            kce.get_extras("Series v01 (Premium).rar")

--- a/tests/parsing/test_release_number.py
+++ b/tests/parsing/test_release_number.py
@@ -1,0 +1,365 @@
+"""Characterization tests for get_release_number and get_release_number_cache.
+
+These tests pin what the production code does TODAY — surprises and all.
+Any FLAG: comment documents a known quirk or potential bug that is pinned as-is.
+
+Verified with: .venv/bin/python -c "import komga_cover_extractor as kce; ..."
+on the library-replacements branch (commit range after ceb171b).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# get_release_number — volume mode (chapter=False, the default)
+# ---------------------------------------------------------------------------
+
+
+class TestGetReleaseNumberVolumeMode:
+    """Volume mode: chapter=False (default). Ceiling at >= 2000."""
+
+    def test_single_volume_v01_returns_int_1(self):
+        """Standard zero-padded volume number parses to integer 1."""
+        result = kce.get_release_number("Series v01 (2021).cbz", chapter=False)
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_single_volume_v01_5_returns_float(self):
+        """Half-volume (point-five) parses to a float, not an int."""
+        result = kce.get_release_number("Series v01.5 (2021).cbz", chapter=False)
+        assert result == 1.5
+        assert isinstance(result, float)
+
+    def test_single_volume_v0_returns_int_0(self):
+        """Volume zero is a valid edge case and returns integer 0.
+
+        Note: '0 or results == 0' guard in the source correctly handles falsy 0.
+        """
+        result = kce.get_release_number("Series v0 (2021).cbz", chapter=False)
+        assert result == 0
+        assert isinstance(result, int)
+
+    def test_single_volume_trailing_point_zero_stripped(self):
+        """Trailing '.0' is stripped before conversion; v10.0 -> 10 (int)."""
+        result = kce.get_release_number("Series v10.0 (2021).cbz", chapter=False)
+        assert result == 10
+        assert isinstance(result, int)
+
+    def test_multi_volume_v01_03_returns_tuple(self):
+        """Keyword-then-range (v01-03) is recognized as multi-volume and returns a tuple.
+
+        FLAG: get_release_number returns a TUPLE for multi-volume, but
+        get_release_number_cache converts that tuple to a LIST. Callers that
+        branch on isinstance(x, list) will not match the raw function's output.
+        """
+        result = kce.get_release_number("Series v01-03 (2021).cbz", chapter=False)
+        assert result == (1, 3)
+        assert isinstance(result, tuple)
+
+    def test_multi_volume_float_range_returns_tuple_of_floats(self):
+        """Float endpoints in a range produce a tuple of floats."""
+        result = kce.get_release_number("Series v01.5-03.5 (2021).cbz", chapter=False)
+        assert result == (1.5, 3.5)
+        assert isinstance(result, tuple)
+        assert all(isinstance(v, float) for v in result)
+
+    def test_multi_volume_with_extra_suffix_appends_point5(self):
+        """'_extra' is replaced with '.5' before processing; v01-03_extra -> (1, 3.5)."""
+        result = kce.get_release_number("Series v01-03_extra (2021).cbz", chapter=False)
+        assert result == (1, 3.5)
+        assert isinstance(result, tuple)
+
+    def test_extra_suffix_single_volume_becomes_point5(self):
+        """v01_extra -> 1.5 because '_extra' is replaced with '.5'."""
+        result = kce.get_release_number("Series v01_extra (2021).cbz", chapter=False)
+        assert result == 1.5
+        assert isinstance(result, float)
+
+    def test_repeat_keyword_v01_v03_returns_only_first_number(self):
+        """v01-v03 (keyword repeated before each number) is NOT detected as multi-volume.
+
+        FLAG: check_for_multi_volume_file returns False for 'v01-v03' because the
+        regex requires a single keyword prefix followed by two bare numbers separated
+        by a dash — the repeated 'v' keyword breaks the match. As a result only the
+        first number (1) is returned instead of the expected range (1, 3). Callers
+        must use the canonical 'v01-03' form to get a proper range.
+        """
+        # Verify that the multi-volume detector is indeed False for the repeated-keyword form
+        assert kce.check_for_multi_volume_file("Series v01-v03 (2021).cbz") is False
+        result = kce.get_release_number("Series v01-v03 (2021).cbz", chapter=False)
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_repeat_keyword_v1_v3_returns_only_first_number(self):
+        """Same repeat-keyword truncation for non-padded v1-v3."""
+        assert kce.check_for_multi_volume_file("Series v1-v3 (2021).cbz") is False
+        result = kce.get_release_number("Series v1-v3 (2021).cbz", chapter=False)
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_year_like_v2023_blocked_by_ceiling(self):
+        """v2023 in volume mode returns '' because 2023 >= 2000 is filtered out.
+
+        FLAG: The >= 2000 ceiling is a heuristic to avoid treating publication
+        years embedded in filenames as volume numbers. It's only applied in volume
+        mode; chapter mode has no ceiling (see chapter tests below).
+        """
+        result = kce.get_release_number("Series v2023 (2021).cbz", chapter=False)
+        assert result == ""
+
+    def test_v2000_exactly_at_ceiling_returns_empty(self):
+        """Exactly 2000 is blocked (ceiling condition is results < 2000)."""
+        result = kce.get_release_number("Series v2000 (2021).cbz", chapter=False)
+        assert result == ""
+
+    def test_v1999_just_below_ceiling_returns_int(self):
+        """1999 is just below the ceiling and passes through as an int."""
+        result = kce.get_release_number("Series v1999 (2021).cbz", chapter=False)
+        assert result == 1999
+        assert isinstance(result, int)
+
+    def test_v100_well_below_ceiling_returns_int(self):
+        """Normal large-ish volume number well below 2000 passes through."""
+        result = kce.get_release_number("Series v100 (2021).cbz", chapter=False)
+        assert result == 100
+        assert isinstance(result, int)
+
+    def test_bare_year_in_filename_blocked(self):
+        """A bare 2023 (not prefixed with 'v') is also filtered by the ceiling."""
+        result = kce.get_release_number("Series 2023 (2021).cbz", chapter=False)
+        assert result == ""
+
+    def test_no_volume_number_returns_empty_string(self):
+        """A filename with no recognizable volume number returns empty string."""
+        result = kce.get_release_number("Series (2021).cbz", chapter=False)
+        assert result == ""
+
+    def test_return_type_is_empty_string_not_none(self):
+        """The 'not found' sentinel is '' (str), never None."""
+        result = kce.get_release_number("No Number Here.cbz", chapter=False)
+        assert result == ""
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# get_release_number — chapter mode (chapter=True)
+# ---------------------------------------------------------------------------
+
+
+class TestGetReleaseNumberChapterMode:
+    """Chapter mode: chapter=True. No >= 2000 ceiling applies."""
+
+    def test_chapter_001_returns_int(self):
+        """Standard chapter number returns an int."""
+        result = kce.get_release_number("Chapter 001 (2023).cbz", chapter=True)
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_chapter_000_returns_int_0(self):
+        """Chapter zero is valid and returns 0 (int)."""
+        result = kce.get_release_number("Chapter 000 (2023).cbz", chapter=True)
+        assert result == 0
+        assert isinstance(result, int)
+
+    def test_chapter_float_returns_float(self):
+        """Decimal chapter number returns a float."""
+        result = kce.get_release_number("Chapter 001.5 (2023).cbz", chapter=True)
+        assert result == 1.5
+        assert isinstance(result, float)
+
+    def test_chapter_multi_range_returns_tuple(self):
+        """Chapter range 001-003 returns a tuple (same as volume multi-range)."""
+        result = kce.get_release_number("Chapter 001-003 (2023).cbz", chapter=True)
+        assert result == (1, 3)
+        assert isinstance(result, tuple)
+
+    def test_chapter_2000_passes_no_ceiling(self):
+        """2000 is NOT filtered in chapter mode — no ceiling is applied.
+
+        FLAG: Volume mode blocks numbers >= 2000 as likely publication years.
+        Chapter mode skips this guard entirely (the branch is 'elif chapter: return
+        results'). A chapter numbered 2000 is returned as-is.
+        """
+        result = kce.get_release_number("Chapter 2000 (2023).cbz", chapter=True)
+        assert result == 2000
+        assert isinstance(result, int)
+
+    def test_chapter_1999_passes_in_chapter_mode(self):
+        """1999 passes in chapter mode (would also pass volume mode, confirming
+        the chapter mode doesn't accidentally add its own ceiling)."""
+        result = kce.get_release_number("Chapter 1999 (2023).cbz", chapter=True)
+        assert result == 1999
+        assert isinstance(result, int)
+
+    def test_chapter_9999_passes_in_chapter_mode(self):
+        """Very large chapter number passes in chapter mode (no upper bound)."""
+        result = kce.get_release_number("Chapter 9999 (2023).cbz", chapter=True)
+        assert result == 9999
+        assert isinstance(result, int)
+
+    def test_bare_2023_returns_2023_in_chapter_mode(self):
+        """A bare year-like number 2023 in chapter mode is NOT filtered."""
+        result = kce.get_release_number("Series 2023 (2021).cbz", chapter=True)
+        assert result == 2023
+        assert isinstance(result, int)
+
+    def test_chapter_no_number_returns_empty_string(self):
+        """No recognizable chapter number still returns '' in chapter mode."""
+        result = kce.get_release_number("Series (2021).cbz", chapter=True)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# get_release_number_cache — tuple -> list conversion
+# ---------------------------------------------------------------------------
+
+
+class TestGetReleaseNumberCache:
+    """get_release_number_cache wraps get_release_number and converts any
+    tuple result to a list, leaving all other types unchanged.
+
+    FLAG: This creates a contract mismatch — the underlying function returns
+    tuple for multi-volume; the cache wrapper returns list. Callers that
+    branch on isinstance(x, list) will see True only for the wrapper's output,
+    not for the raw function's output. This is intentional per the source code
+    pattern ('callers branch on isinstance(x, list)').
+    """
+
+    def test_single_volume_int_unchanged(self):
+        """Single volume: int passes through unchanged."""
+        result = kce.get_release_number_cache("Series v01 (2021).cbz", chapter=False)
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_single_volume_float_unchanged(self):
+        """Single half-volume: float passes through unchanged."""
+        result = kce.get_release_number_cache(
+            "Series v01.5 (2021).cbz", chapter=False
+        )
+        assert result == 1.5
+        assert isinstance(result, float)
+
+    def test_volume_zero_unchanged(self):
+        """Volume zero passes through unchanged."""
+        result = kce.get_release_number_cache("Series v0 (2021).cbz", chapter=False)
+        assert result == 0
+        assert isinstance(result, int)
+
+    def test_empty_string_unchanged(self):
+        """Empty-string sentinel passes through unchanged."""
+        result = kce.get_release_number_cache("Series (2021).cbz", chapter=False)
+        assert result == ""
+
+    def test_multi_volume_tuple_converted_to_list(self):
+        """Multi-volume tuple (1, 3) is converted to a list [1, 3].
+
+        FLAG: Raw get_release_number returns tuple; cache wrapper returns list.
+        This is the explicit tuple-vs-list contract mismatch described in the
+        module-level docstring.
+        """
+        raw = kce.get_release_number("Series v01-03 (2021).cbz", chapter=False)
+        assert isinstance(raw, tuple), "raw function must return a tuple"
+
+        cached = kce.get_release_number_cache(
+            "Series v01-03 (2021).cbz", chapter=False
+        )
+        assert isinstance(cached, list), "cache wrapper must convert tuple to list"
+        assert cached == [1, 3]
+
+    def test_multi_volume_list_element_types_are_int(self):
+        """Elements inside the converted list are ints for whole-number ranges."""
+        result = kce.get_release_number_cache(
+            "Series v01-03 (2021).cbz", chapter=False
+        )
+        assert all(isinstance(v, int) for v in result)
+
+    def test_multi_volume_float_range_converted_to_list_of_floats(self):
+        """Float-endpoint range tuple -> list of floats."""
+        result = kce.get_release_number_cache(
+            "Series v01.5-03.5 (2021).cbz", chapter=False
+        )
+        assert result == [1.5, 3.5]
+        assert isinstance(result, list)
+        assert all(isinstance(v, float) for v in result)
+
+    def test_chapter_multi_range_converted_to_list(self):
+        """Chapter range tuple also gets converted to a list by the cache wrapper."""
+        raw = kce.get_release_number("Chapter 001-003 (2023).cbz", chapter=True)
+        assert isinstance(raw, tuple)
+
+        cached = kce.get_release_number_cache(
+            "Chapter 001-003 (2023).cbz", chapter=True
+        )
+        assert isinstance(cached, list)
+        assert cached == [1, 3]
+
+    def test_chapter_2000_int_unchanged(self):
+        """Chapter 2000 int passes through the cache wrapper unchanged."""
+        result = kce.get_release_number_cache(
+            "Chapter 2000 (2023).cbz", chapter=True
+        )
+        assert result == 2000
+        assert isinstance(result, int)
+
+    def test_repeat_keyword_v01_v03_single_int_unchanged(self):
+        """Repeat-keyword v01-v03 returns 1 (int); cache wrapper leaves it alone."""
+        result = kce.get_release_number_cache(
+            "Series v01-v03 (2021).cbz", chapter=False
+        )
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_ceiling_blocked_year_empty_string_unchanged(self):
+        """Year-like v2023 blocked in volume mode; cache wrapper returns '' unchanged."""
+        result = kce.get_release_number_cache(
+            "Series v2023 (2021).cbz", chapter=False
+        )
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# check_for_multi_volume_file — companion helper, tested for completeness
+# ---------------------------------------------------------------------------
+
+
+class TestCheckForMultiVolumeFile:
+    """Pin check_for_multi_volume_file's boolean contract as it directly
+    affects get_release_number's branching behavior."""
+
+    def test_v01_03_is_multi(self):
+        """Standard range 'v01-03' is recognized as multi-volume."""
+        assert kce.check_for_multi_volume_file("Series v01-03 (2021).cbz") is True
+
+    def test_v001_003_is_multi(self):
+        """v001-003 (three-digit padded) is also recognized as multi-volume."""
+        assert kce.check_for_multi_volume_file("Series v001-003 (2021).cbz") is True
+
+    def test_v01_v03_is_not_multi(self):
+        """Repeat-keyword 'v01-v03' is NOT recognized as multi-volume.
+
+        FLAG: The regex requires a single keyword prefix then bare numbers; the
+        second 'v' keyword prefix breaks recognition, causing only the first
+        number to be returned by get_release_number.
+        """
+        assert kce.check_for_multi_volume_file("Series v01-v03 (2021).cbz") is False
+
+    def test_v1_v3_is_not_multi(self):
+        """Same repeat-keyword failure for non-padded 'v1-v3'."""
+        assert kce.check_for_multi_volume_file("Series v1-v3 (2021).cbz") is False
+
+    def test_single_volume_is_not_multi(self):
+        """A filename with only one volume number is not multi-volume."""
+        assert kce.check_for_multi_volume_file("Series v01 (2021).cbz") is False
+
+    def test_chapter_range_is_multi_in_chapter_mode(self):
+        """Chapter range 001-003 is recognized as multi-volume in chapter mode."""
+        assert (
+            kce.check_for_multi_volume_file(
+                "Chapter 001-003 (2023).cbz", chapter=True
+            )
+            is True
+        )

--- a/tests/parsing/test_release_year.py
+++ b/tests/parsing/test_release_year.py
@@ -1,0 +1,236 @@
+"""Characterization tests for ``kce.get_release_year``.
+
+Signature (verified via Serena):
+    get_release_year(name: str, metadata: dict | None = None) -> str | int | None
+
+Return-type contract observed in the wild (pinned as-is):
+  * Filename path: returns the year as a **str** (e.g. ``'2021'``), because the
+    regex just calls ``.group()[1:-1]`` on the raw text.
+  * Metadata path: returns the year as an **int** (e.g. ``2021``), because the
+    code does ``result = int(release_year_from_file)``.
+  * Absent/invalid year: returns ``None``.
+
+FLAG: the return type is inconsistent between the two code paths — filename yields
+str, metadata yields int.  This is pinned as-is; do not "fix" in production here.
+"""
+
+from __future__ import annotations
+
+import pytest
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helper alias
+# ---------------------------------------------------------------------------
+
+def gry(name: str, metadata=None):
+    """Thin wrapper so call sites stay short."""
+    return kce.get_release_year(name, metadata=metadata)
+
+
+# ---------------------------------------------------------------------------
+# Filename-based extraction (returns STR)
+# ---------------------------------------------------------------------------
+
+class TestFilenameYear:
+    """Year extracted from the filename always returns a plain string."""
+
+    def test_round_parens_returns_str(self):
+        """Standard ``(YYYY)`` in filename → string year."""
+        result = gry("My Series (2021)")
+        assert result == "2021"
+        # FLAG: filename path returns str, not int
+        assert isinstance(result, str)
+
+    def test_square_brackets_returns_str(self):
+        """``[YYYY]`` bracket style is supported and also returns str."""
+        result = gry("My Series [2018]")
+        assert result == "2018"
+        assert isinstance(result, str)
+
+    def test_curly_braces_returns_str(self):
+        """``{YYYY}`` brace style is supported and also returns str."""
+        result = gry("My Series {2017}")
+        assert result == "2017"
+        assert isinstance(result, str)
+
+    def test_year_in_middle_of_name(self):
+        """Year does not have to be at the end of the filename."""
+        result = gry("My Series (2021) Vol 1")
+        assert result == "2021"
+        assert isinstance(result, str)
+
+    def test_filename_year_takes_precedence_over_metadata(self):
+        """When filename contains a year, metadata is ignored entirely."""
+        result = gry("My Series (2021)", metadata={"Summary": "desc", "Year": "2020"})
+        # Filename wins — returns str '2021', not int from metadata
+        assert result == "2021"
+        assert isinstance(result, str)
+
+    def test_two_digit_year_not_matched(self):
+        """``(99)`` is only 2 digits — pattern requires exactly 4 digits → None."""
+        assert gry("My Series (99)") is None
+
+    def test_five_digit_year_not_matched(self):
+        """``(20201)`` has 5 digits — pattern requires exactly 4 digits → None."""
+        assert gry("My Series (20201)") is None
+
+    def test_empty_name(self):
+        """Empty filename string → None."""
+        assert gry("") is None
+
+    def test_name_with_no_year_at_all(self):
+        """Name has no bracketed year → None (no metadata supplied)."""
+        assert gry("No Year Here") is None
+
+
+# ---------------------------------------------------------------------------
+# Metadata path — ComicInfo ``Year`` field (returns INT)
+# ---------------------------------------------------------------------------
+
+class TestMetadataYearField:
+    """Metadata ``Year`` key is only trusted when ``Summary`` is also present."""
+
+    def test_year_str_with_summary_returns_int(self):
+        """``Year='2020'`` with ``Summary`` present → integer 2020."""
+        result = gry("My Series", metadata={"Summary": "Some description", "Year": "2020"})
+        assert result == 2020
+        # FLAG: metadata path returns int, filename path returns str
+        assert isinstance(result, int)
+
+    def test_year_below_floor_1949_returns_none(self):
+        """Years strictly below 1950 are discarded — 1949 → None."""
+        assert gry("My Series", metadata={"Summary": "desc", "Year": "1949"}) is None
+
+    def test_year_below_floor_1900_returns_none(self):
+        """Far below floor (1900) → None."""
+        assert gry("My Series", metadata={"Summary": "desc", "Year": "1900"}) is None
+
+    def test_year_at_floor_1950_is_accepted(self):
+        """Exactly 1950 is at the boundary and IS accepted → 1950 (int)."""
+        result = gry("My Series", metadata={"Summary": "desc", "Year": "1950"})
+        assert result == 1950
+        assert isinstance(result, int)
+
+    def test_year_missing_summary_returns_none(self):
+        """``Year`` without accompanying ``Summary`` is ignored → None.
+
+        FLAG: the code requires BOTH Summary and Year to trust the metadata year;
+        a lone Year field is silently discarded.
+        """
+        assert gry("My Series", metadata={"Year": "2020"}) is None
+
+    def test_year_key_absent_returns_none(self):
+        """``Summary`` present but ``Year`` absent → None."""
+        assert gry("My Series", metadata={"Summary": "desc"}) is None
+
+    def test_non_digit_year_string_returns_none(self):
+        """Non-numeric Year string (fails isdigit check) → None."""
+        assert gry("My Series", metadata={"Summary": "desc", "Year": "abc2"}) is None
+
+    def test_five_digit_year_string_returns_none(self):
+        """5-digit Year string (fails len==4 check) → None."""
+        assert gry("My Series", metadata={"Summary": "desc", "Year": "20201"}) is None
+
+    def test_year_as_int_in_metadata_raises_typeerror(self):
+        """Passing Year as a Python int (instead of str) crashes with TypeError.
+
+        FLAG: the code calls ``len(release_year_from_file)`` which fails on int.
+        ComicInfo parsers normally return strings, so this edge case is a latent bug.
+        """
+        with pytest.raises(TypeError, match="object of type 'int' has no len"):
+            gry("My Series", metadata={"Summary": "desc", "Year": 2020})
+
+
+# ---------------------------------------------------------------------------
+# Metadata path — EPUB ``dc:date`` field (returns INT)
+# ---------------------------------------------------------------------------
+
+class TestMetadataDcDate:
+    """dc:date is used when ``dc:description`` is also present (EPUB path)."""
+
+    def test_full_iso_date_extracts_year_as_int(self):
+        """``dc:date='2019-05-01'`` → integer 2019."""
+        result = gry(
+            "My Series",
+            metadata={"dc:description": "Some description", "dc:date": "2019-05-01"},
+        )
+        assert result == 2019
+        assert isinstance(result, int)
+
+    def test_bare_year_dc_date_returns_int(self):
+        """``dc:date='2019'`` (no month/day) → integer 2019."""
+        result = gry(
+            "My Series",
+            metadata={"dc:description": "desc", "dc:date": "2019"},
+        )
+        assert result == 2019
+        assert isinstance(result, int)
+
+    def test_dc_date_with_surrounding_whitespace(self):
+        """Leading/trailing whitespace is stripped before parsing."""
+        result = gry(
+            "My Series",
+            metadata={"dc:description": "desc", "dc:date": " 2019-05-01 "},
+        )
+        assert result == 2019
+        assert isinstance(result, int)
+
+    def test_dc_date_below_floor_returns_none(self):
+        """dc:date year of 1900 is below the 1950 floor → None."""
+        assert gry(
+            "My Series",
+            metadata={"dc:description": "desc", "dc:date": "1900-01-01"},
+        ) is None
+
+    def test_dc_date_at_floor_1950_accepted(self):
+        """dc:date year of exactly 1950 passes the floor check → 1950 (int)."""
+        result = gry(
+            "My Series",
+            metadata={"dc:description": "desc", "dc:date": "1950-01-01"},
+        )
+        assert result == 1950
+        assert isinstance(result, int)
+
+    def test_dc_date_non_digit_first_segment_returns_none(self):
+        """Non-numeric first segment of dc:date (fails isdigit) → None."""
+        assert gry(
+            "My Series",
+            metadata={"dc:description": "desc", "dc:date": "abc-def"},
+        ) is None
+
+    def test_dc_date_missing_dc_description_returns_none(self):
+        """dc:date alone without dc:description is not trusted → None.
+
+        FLAG: the code requires BOTH dc:description and dc:date; sole dc:date ignored.
+        """
+        assert gry("My Series", metadata={"dc:date": "2019-05-01"}) is None
+
+    def test_dc_description_without_dc_date_returns_none(self):
+        """dc:description present but dc:date absent → None."""
+        assert gry("My Series", metadata={"dc:description": "desc"}) is None
+
+
+# ---------------------------------------------------------------------------
+# No metadata / absent year
+# ---------------------------------------------------------------------------
+
+class TestNoYear:
+    """Catches all the empty/None/missing cases."""
+
+    def test_none_metadata_returns_none(self):
+        """Explicitly passing ``metadata=None`` → None."""
+        assert gry("My Series", metadata=None) is None
+
+    def test_default_metadata_returns_none(self):
+        """Omitting metadata entirely (defaults to None) → None."""
+        assert gry("My Series") is None
+
+    def test_empty_dict_metadata_returns_none(self):
+        """Empty metadata dict (no keys) → None."""
+        assert gry("My Series", metadata={}) is None
+
+    def test_no_year_name_no_metadata(self):
+        """Plain series name with no year pattern → None."""
+        assert gry("Sword Art Online") is None

--- a/tests/parsing/test_series_name.py
+++ b/tests/parsing/test_series_name.py
@@ -1,0 +1,278 @@
+"""Characterization tests for ``kce.get_series_name_from_volume`` and
+``kce.get_series_name_from_chapter``.
+
+Both functions extract a bare series name from a filename.  All expected values
+were verified against the live interpreter before being written here.
+
+Signatures (verified via Serena + inspect):
+    get_series_name_from_volume(name, root, test_mode=False, second=False) -> str
+        @lru_cache(maxsize=3500)
+        test_mode=True prevents is_one_shot from hitting the filesystem.
+
+    get_series_name_from_chapter(name, root, chapter_number='', second=False) -> str
+        No lru_cache; no test_mode param.
+        Falls back to os.path.basename(root) when the extracted series is empty
+        (and second=False, and root is not in download_folders/paths).
+"""
+
+from __future__ import annotations
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Aliases to keep call-sites tidy
+# ---------------------------------------------------------------------------
+
+def gsnfv(name: str, root: str = "/tmp/nope", *, test_mode: bool = True) -> str:
+    """Thin wrapper around get_series_name_from_volume."""
+    return kce.get_series_name_from_volume(name, root, test_mode=test_mode)
+
+
+def gsnfc(name: str, root: str = "/tmp/nope", chapter_number: str = "") -> str:
+    """Thin wrapper around get_series_name_from_chapter."""
+    return kce.get_series_name_from_chapter(name, root, chapter_number)
+
+
+# ===========================================================================
+# get_series_name_from_volume
+# ===========================================================================
+
+
+class TestGetSeriesNameFromVolume:
+    """Pin the exact series string extracted from volume filenames."""
+
+    # --- standard volume keyword variants ---
+
+    def test_volume_v_prefix_with_year_and_digital_tag(self):
+        """``v01 (2021) (Digital)`` → series name before the volume marker."""
+        assert gsnfv("Sword Art Online v01 (2021) (Digital).cbz") == "Sword Art Online"
+
+    def test_volume_keyword_long_form(self):
+        """``Volume 10`` (long-form keyword) → bare series name."""
+        assert gsnfv("My Hero Academia Volume 10.cbz") == "My Hero Academia"
+
+    def test_volume_vol_dotted(self):
+        """``Vol. 1`` dotted abbreviation is recognised."""
+        assert gsnfv("Death Note Vol. 1.cbz") == "Death Note"
+
+    def test_volume_with_group_tag_and_year(self):
+        """Group tag and year in brackets are stripped after the volume number."""
+        assert gsnfv("Fullmetal Alchemist v01 [Group] (2003).cbz") == "Fullmetal Alchemist"
+
+    def test_volume_with_complete_tag_in_brackets(self):
+        """``[Complete]`` bracket tag after volume number is stripped normally."""
+        assert gsnfv("Dragon Ball Z Volume 01 [Complete] (2021).cbz") == "Dragon Ball Z"
+
+    # --- "Complete" suffix stripping ---
+
+    def test_complete_suffix_stripped_with_dash(self):
+        """``- Complete`` after series name is stripped (dash form)."""
+        assert gsnfv("Attack on Titan - Complete v01.cbz") == "Attack on Titan"
+
+    def test_complete_suffix_stripped_no_volume_number(self):
+        """``- Complete.epub`` with no volume number — series still extracted."""
+        assert gsnfv("Series Name - Complete.epub") == "Series Name"
+
+    def test_complete_suffix_stripped_with_colon(self):
+        """``My Series: Complete v01.cbz`` — colon form of Complete stripped."""
+        assert gsnfv("My Series: Complete v01.cbz") == "My Series"
+
+    def test_complete_suffix_stripped_with_premium_bracket(self):
+        """Full pattern ``- Complete v01 [Premium]`` → bare series name."""
+        assert gsnfv("Series Name - Complete v01 [Premium].epub") == "Series Name"
+
+    def test_complete_no_dash_not_stripped(self):
+        """``Complete`` without a preceding dash/colon is NOT stripped.
+
+        FLAG: the regex ``(-|:)\\s*Complete$`` requires a dash or colon before
+        'Complete', so "One Piece Complete.cbz" retains the word in its result.
+        In this particular file the whole name is returned because is_one_shot
+        detects it as a one-shot (no volume number) and keeps the base name.
+        """
+        assert gsnfv("One Piece Complete.cbz") == "One Piece Complete"
+
+    # --- [WN] / leading-bracket tag stripping ---
+
+    def test_wn_leading_bracket_stripped_from_volume(self):
+        """``[WN]`` prefix is stripped before the series name is extracted."""
+        assert gsnfv("[WN] My Series v01.cbz") == "My Series"
+
+    def test_wn_leading_bracket_stripped_sword_art(self):
+        """``[WN]`` prefix stripping works with multi-word series name."""
+        assert gsnfv("[WN] Sword Art Online v01.cbz") == "Sword Art Online"
+
+    # --- One-shot passthrough ---
+
+    def test_one_shot_bare_filename_passthrough(self):
+        """A file with no volume number is detected as one-shot; name preserved.
+
+        ``Series Name.cbz`` has no volume keyword so ``is_one_shot`` returns
+        True (test_mode skips disk lookup).  The one-shot branch strips
+        brackets/extension and returns the base series name unchanged.
+        """
+        assert gsnfv("Series Name.cbz") == "Series Name"
+
+    def test_one_shot_with_year_bracket_stripped(self):
+        """One-shot file with a year bracket → year bracket is stripped."""
+        assert gsnfv("My Series [2021].cbz") == "My Series"
+
+    def test_one_shot_with_group_bracket_stripped(self):
+        """One-shot file with a group/release tag bracket → bracket stripped."""
+        assert gsnfv("My Oneshot [Group] (2021).cbz") == "My Oneshot"
+
+    def test_one_shot_string_in_name_space_separated_kept(self):
+        """Space-separated ``One Shot`` is NOT matched by the one-shot strip regex.
+
+        FLAG: the strip regex ``(-\\s*)Ones?(-|)shot\\s*`` requires 'One' followed
+        directly by an optional dash then 'shot' (no space).  So "Story - One Shot"
+        passes through the strip step unchanged.  The file IS detected as a one-shot
+        by is_one_shot and the full name (minus extension) is returned.
+        """
+        assert gsnfv("Story - One Shot.cbz") == "Story - One Shot"
+
+    def test_one_shot_hyphenated_stripped(self):
+        """``- One-shot`` (hyphenated) IS matched by the strip regex → stripped."""
+        assert gsnfv("Story - One-shot.cbz") == "Story"
+
+    def test_one_shot_camelcase_stripped(self):
+        """``- Oneshot`` (no separator) IS matched by the strip regex → stripped."""
+        assert gsnfv("Story - Oneshot.cbz") == "Story"
+
+    # --- Trailing-comma removal ---
+
+    def test_trailing_comma_removed(self):
+        """A trailing comma before the volume keyword is removed from the result.
+
+        E.g. ``Berserk, v01.cbz``.  The volume regex absorbs everything from
+        ``, v01`` onward; the bare 'Berserk,' is then cleaned to 'Berserk'.
+        """
+        assert gsnfv("Berserk, v01.cbz") == "Berserk"
+
+    def test_trailing_comma_with_volume_word(self):
+        """Trailing comma also cleaned when the ``Volume`` keyword form is used."""
+        assert gsnfv("Series, Volume 1.cbz") == "Series"
+
+    # --- Underscore replacement ---
+
+    def test_underscores_replaced_by_spaces(self):
+        """Underscores in the series name portion are replaced with spaces."""
+        assert gsnfv("My_Series v01.cbz") == "My Series"
+
+    # --- _extra handling (half-volume artefact) ---
+
+    def test_extra_suffix_replaced_with_dot5(self):
+        """``_extra`` is replaced with ``.5`` before further processing.
+
+        E.g. ``Series_extra v01.cbz``:  the underscore in ``_extra`` is replaced
+        first (``_extra`` → ``.5``), yielding ``Series.5 v01.cbz``, then the
+        volume keyword strips everything from ``v01`` onward → ``'Series.5'``.
+        """
+        assert gsnfv("Series_extra v01.cbz") == "Series.5"
+
+    def test_extra_in_extensionless_name(self):
+        """``_extra`` at the end of a one-shot name → trailing ``.`` preserved.
+
+        FLAG: ``Series Name_extra.cbz`` → ``_extra`` → ``.5`` in the middle of
+        name then is_one_shot branch processes it.  Result ends with a period,
+        which is a minor formatting quirk pinned as-is.
+        """
+        result = gsnfv("Series Name_extra.cbz")
+        assert result == "Series Name."
+
+
+# ===========================================================================
+# get_series_name_from_chapter
+# ===========================================================================
+
+
+class TestGetSeriesNameFromChapter:
+    """Pin the exact series string extracted from chapter filenames.
+
+    Note: get_series_name_from_chapter has NO test_mode param and NO lru_cache.
+    When the extracted series is empty (and second=False), it falls back to
+    os.path.basename(root) processed through another call to itself.
+    """
+
+    # --- standard chapter keyword variants ---
+
+    def test_chapter_c_prefix(self):
+        """``c001`` chapter prefix → series name before the chapter marker."""
+        assert gsnfc("Series c001.cbz") == "Series"
+
+    def test_chapter_c_prefix_multiword(self):
+        """Multi-word series with ``c010`` chapter prefix."""
+        assert gsnfc("My Series c010.cbz") == "My Series"
+
+    def test_chapter_chapter_keyword(self):
+        """Long-form ``Chapter 001`` keyword → series name extracted."""
+        assert gsnfc("My Series Chapter 001.cbz") == "My Series"
+
+    def test_chapter_ch_dotted(self):
+        """``Ch. 5`` dotted abbreviation → series name extracted."""
+        assert gsnfc("My Series - Ch. 5.cbz") == "My Series"
+
+    def test_chapter_ch_prefix_no_dot(self):
+        """``ch001`` without dot is also a recognised chapter marker."""
+        assert gsnfc("My Series - ch001.cbz") == "My Series"
+
+    def test_chapter_c_prefix_tokyo_ghoul(self):
+        """Single-word series with c-prefix chapter."""
+        assert gsnfc("TokyoGhoul c001.cbz") == "TokyoGhoul"
+
+    # --- [WN] / leading-bracket tag stripping ---
+
+    def test_wn_leading_bracket_stripped_from_chapter(self):
+        """``[WN]`` prefix is stripped in the chapter path too."""
+        assert gsnfc("[WN] My Series c001.cbz") == "My Series"
+
+    # --- root fallback when series is empty ---
+
+    def test_bare_chapter_number_falls_back_to_root(self):
+        """A bare chapter number with no series prefix yields empty series.
+
+        FLAG: when the extracted series name is empty, the function falls back
+        to ``os.path.basename(root)`` (processed via a recursive call with
+        ``second=True``).  So ``'010.cbz'`` with root ``'/tmp/nope'`` returns
+        the basename ``'nope'``, not an empty string.
+        """
+        assert gsnfc("010.cbz", root="/tmp/nope") == "nope"
+
+    def test_bare_chapter_number_different_root(self):
+        """Root fallback uses the actual basename of whatever root is passed."""
+        assert gsnfc("010.cbz", root="/tmp/my_series") == "my series"
+
+    def test_bare_chapter_number_second_true_returns_empty(self):
+        """With ``second=True`` the root fallback is suppressed → empty string."""
+        result = kce.get_series_name_from_chapter("010.cbz", "/tmp/nope", "", second=True)
+        assert result == ""
+
+    # --- chapter_number param does not change the series extraction ---
+
+    def test_chapter_number_param_does_not_affect_series(self):
+        """Providing an explicit chapter_number does not change the series result."""
+        assert gsnfc("Series c001.cbz", chapter_number="1") == "Series"
+
+    # --- _extra suffix in chapter names ---
+
+    def test_extra_suffix_in_chapter_name(self):
+        """``_extra`` between series and chapter marker: ``_extra`` → ``.5``."""
+        assert gsnfc("Series_extra c001.cbz") == "Series.5"
+
+    # --- unrecognised chapter-like patterns are NOT stripped ---
+
+    def test_hash_chapter_number_not_stripped(self):
+        """``#010`` is NOT in the chapter search patterns → name is NOT split.
+
+        FLAG: ``My Series #010.cbz`` is returned as-is (minus the extension)
+        because none of the compiled chapter_search_patterns_comp match ``#010``.
+        """
+        assert gsnfc("My Series #010.cbz") == "My Series #010"
+
+    def test_bare_number_dash_form_not_stripped(self):
+        """``- 010`` dash+number pattern is not a recognised chapter marker.
+
+        FLAG: ``My Series - 010.cbz`` is not split; the full name minus
+        extension is returned.
+        """
+        assert gsnfc("My Series - 010.cbz") == "My Series - 010"

--- a/tests/parsing/test_subtitle_part.py
+++ b/tests/parsing/test_subtitle_part.py
@@ -1,0 +1,542 @@
+"""Characterization tests for ``kce.get_file_part``, ``kce.get_subtitle_from_dash``,
+and ``kce.get_shortened_title``.
+
+All return values were observed by running the real functions in .venv/bin/python
+before each assertion was written.  Surprising/buggy behaviours are noted with
+``# FLAG:`` comments.
+
+Verified function signatures (via Serena):
+  get_file_part(file, chapter=False, series_name=None, subtitle=None)
+  get_subtitle_from_dash(title, replace=False)
+  get_shortened_title(title)
+"""
+
+from __future__ import annotations
+
+import pytest
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helper aliases
+# ---------------------------------------------------------------------------
+
+def gfp(file, chapter=False, series_name=None, subtitle=None):
+    """Short alias for get_file_part."""
+    return kce.get_file_part(file, chapter=chapter, series_name=series_name, subtitle=subtitle)
+
+
+def gsd(title, replace=False):
+    """Short alias for get_subtitle_from_dash."""
+    return kce.get_subtitle_from_dash(title, replace=replace)
+
+
+def gst(title):
+    """Short alias for get_shortened_title."""
+    return kce.get_shortened_title(title)
+
+
+# ===========================================================================
+# get_file_part
+# ===========================================================================
+
+class TestGetFilePart:
+    """Pin the behaviour of ``get_file_part`` in volume (non-chapter) mode."""
+
+    # -----------------------------------------------------------------------
+    # Basic matches — volume mode (chapter=False)
+    # -----------------------------------------------------------------------
+
+    def test_simple_part_2_returns_int(self):
+        """'Part 2' in filename → integer 2."""
+        result = gfp("Series Part 2.cbz")
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_part_only_no_series_prefix(self):
+        """File starting with 'Part N' (no volume keyword prefix) → int N."""
+        result = gfp("Part 5.cbz")
+        assert result == 5
+        assert isinstance(result, int)
+
+    def test_part_with_volume_prefix(self):
+        """'Volume 1 Part 2' extracts only the part number."""
+        result = gfp("Volume 1 Part 2.cbz")
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_part_10(self):
+        """Multi-digit part number is extracted correctly."""
+        result = gfp("Series Part 10.cbz")
+        assert result == 10
+        assert isinstance(result, int)
+
+    def test_case_insensitive_PART(self):
+        """'PART' (uppercase) is treated the same as 'Part'."""
+        result = gfp("Series PART 2.cbz")
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_case_insensitive_part_lower(self):
+        """'part' (lowercase) is treated the same as 'Part'."""
+        result = gfp("Series part 2.cbz")
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_part_dash_separator(self):
+        """'Part-2' (dash separator) is matched → 2."""
+        result = gfp("Series Part-2.cbz")
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_part_dot_separator(self):
+        """'Part.2' (dot separator) is matched → 2."""
+        result = gfp("Series Part.2.cbz")
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_part_underscore_no_match(self):
+        """'Part_2' (underscore separator) does NOT match.
+
+        FLAG: the regex ``rx_search_part`` pattern ``r'(\\b(Part)([-_. ]|)([0-9]+)\\b)'``
+        does include underscore in the separator class, so it WOULD match 'Part_2'.
+        However, the guard ``contains_keyword`` uses ``re.search(r'\\bpart\\b', ...)``
+        which requires word boundaries on BOTH sides of 'part'.  In 'Part_2', the
+        underscore is a word character, so there is no ``\\b`` after 't' → the guard
+        evaluates to None (falsy) → the function returns '' without ever reaching the
+        regex search step.
+        """
+        result = gfp("Series Part_2.cbz")
+        assert result == ""
+
+    def test_no_part_keyword_returns_empty(self):
+        """Filename with no 'part' keyword → empty string."""
+        result = gfp("No part here.cbz")
+        assert result == ""
+
+    def test_empty_filename_returns_empty(self):
+        """Empty string → empty string."""
+        result = gfp("")
+        assert result == ""
+
+    def test_whitespace_filename_returns_empty(self):
+        """Whitespace-only string → empty string."""
+        result = gfp("   ")
+        assert result == ""
+
+    def test_part_range_returns_first(self):
+        """'Part 2-3' — the regex ``([0-9]+)\\b`` captures only the first integer."""
+        result = gfp("Series Part 2-3.cbz")
+        assert result == 2
+        assert isinstance(result, int)
+
+    # -----------------------------------------------------------------------
+    # Decimal/float truncation — the FLAG case
+    # -----------------------------------------------------------------------
+
+    def test_part_2_point_5_truncates_to_int_2(self):
+        """'Part 2.5' silently truncates to integer 2.
+
+        FLAG: ``rx_search_part`` = ``r'(\\b(Part)([-_. ]|)([0-9]+)\\b)'`` only captures
+        the integer digits before the decimal point because the character-class
+        separator ``([-_. ]|)`` consumes the dot between 'Part' and '2', leaving
+        only '2' to be captured by ``([0-9]+)``.  The '.5' suffix is never seen.
+        Result is int 2, not float 2.5.
+        """
+        result = gfp("Series Part 2.5.cbz")
+        assert result == 2
+        # FLAG: float 2.5 is silently truncated to int 2
+        assert isinstance(result, int)
+
+    def test_part_3_point_5_truncates_to_int_3(self):
+        """'Part 3.5' likewise truncates to integer 3."""
+        result = gfp("Manga Vol 1 Part 3.5.cbz")
+        assert result == 3
+        assert isinstance(result, int)
+
+    # -----------------------------------------------------------------------
+    # series_name / subtitle stripping
+    # -----------------------------------------------------------------------
+
+    def test_series_name_stripped_before_search(self):
+        """series_name is removed from the filename before part extraction."""
+        result = gfp("My Series Vol 1 Part 2.cbz", series_name="My Series")
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_subtitle_stripped_before_search(self):
+        """subtitle is removed from the filename before part extraction."""
+        result = gfp(
+            "My Series Vol 1 - Sub Part 2.cbz",
+            series_name="My Series",
+            subtitle="Sub",
+        )
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_series_name_not_in_filename_still_works(self):
+        """series_name not present in filename → strips nothing, still matches Part."""
+        result = gfp("Vol 1 Part 2.cbz", series_name="Other Series")
+        assert result == 2
+        assert isinstance(result, int)
+
+    # -----------------------------------------------------------------------
+    # Volume mode: 'x' / '#' indicators are ignored
+    # -----------------------------------------------------------------------
+
+    def test_x_indicator_in_volume_mode_ignored(self):
+        """In volume mode (chapter=False), the 'x' chapter indicator is not used."""
+        result = gfp("Series 1x2.cbz")
+        assert result == ""
+
+    def test_hash_indicator_in_volume_mode_ignored(self):
+        """In volume mode (chapter=False), the '#' chapter indicator is not used."""
+        result = gfp("Series 1#2.cbz")
+        assert result == ""
+
+
+class TestGetFilePartChapterMode:
+    """Pin the behaviour of ``get_file_part`` in chapter mode (chapter=True)."""
+
+    def test_x_indicator_extracts_part_as_int(self):
+        """Chapter indicator 'x' extracts the part number → int."""
+        result = gfp("Series 1x2.cbz", chapter=True)
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_hash_indicator_extracts_part_as_int(self):
+        """Chapter indicator '#' extracts the part number → int."""
+        result = gfp("Series 1#2.cbz", chapter=True)
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_chapter_x_float_part(self):
+        """'1x2.5' — chapter part with decimal → float 2.5 (NOT truncated)."""
+        result = gfp("Chapter 1x2.5.cbz", chapter=True)
+        assert result == 2.5
+        # NOTE: unlike volume mode, the chapter regex captures the full decimal.
+        assert isinstance(result, float)
+
+    def test_chapter_x_int_part(self):
+        """'Chapter 1x3' → integer 3 (no decimal)."""
+        result = gfp("Chapter 1x3.cbz", chapter=True)
+        assert result == 3
+        assert isinstance(result, int)
+
+    def test_chapter_hash_int_part(self):
+        """'Chapter 1#5' → integer 5."""
+        result = gfp("Chapter 1#5.cbz", chapter=True)
+        assert result == 5
+        assert isinstance(result, int)
+
+    def test_chapter_multi_digit_x(self):
+        """'Chapter 10x3' → integer 3."""
+        result = gfp("Chapter 10x3.cbz", chapter=True)
+        assert result == 3
+        assert isinstance(result, int)
+
+    def test_chapter_large_chapter_number(self):
+        """'Chapter 100x5' → integer 5."""
+        result = gfp("Chapter 100x5.cbz", chapter=True)
+        assert result == 5
+        assert isinstance(result, int)
+
+    def test_chapter_range_before_x(self):
+        """'Chapter 1-2x3' — range before x is handled; extracts 3."""
+        result = gfp("Chapter 1-2x3.cbz", chapter=True)
+        assert result == 3
+        assert isinstance(result, int)
+
+    def test_chapter_float_3_point_5(self):
+        """'Chapter 10x3.5' → float 3.5."""
+        result = gfp("Chapter 10x3.5.cbz", chapter=True)
+        assert result == 3.5
+        assert isinstance(result, float)
+
+    def test_chapter_no_indicator_returns_empty(self):
+        """chapter=True but no 'x' or '#' in filename → empty string.
+
+        FLAG: when chapter=True and neither 'x' nor '#' is in the filename,
+        ``contains_indicator`` is False, so the entire block is skipped and ''
+        is returned even if a 'Part N' keyword is present.
+        """
+        result = gfp("Series Part 2.cbz", chapter=True)
+        assert result == ""
+
+    def test_x_only_no_digit_before(self):
+        """'x' only exists in a word (no digit immediately before it) → no match.
+
+        'Seriesx2' does not match the chapter regex because the pattern
+        ``rx_search_chapters`` expects digits before the x.
+        """
+        result = gfp("Seriesx2.cbz", chapter=True)
+        assert result == ""
+
+    def test_x_in_word_but_with_valid_chapter(self):
+        """'Experiment 1x2.cbz' — 'x' appears in 'Experiment' AND as indicator;
+        the chapter regex still extracts part 2 from '1x2'."""
+        result = gfp("Experiment 1x2.cbz", chapter=True)
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_maximum_word_x_no_digit_before(self):
+        """'Maximum 1.cbz' — 'x' is in 'Maximum' but no digit before x → no match.
+
+        ``contains_indicator`` is True (x appears in the string), but
+        ``rx_search_chapters`` requires digits before the x/# indicator,
+        so the search fails → '' returned.
+        """
+        result = gfp("Maximum 1.cbz", chapter=True)
+        assert result == ""
+
+    def test_chapter_with_series_name_stripped(self):
+        """series_name stripping also works in chapter mode."""
+        result = gfp("My Series 1x2.cbz", chapter=True, series_name="My Series")
+        # FLAG: series_name stripping only happens inside the 'if not chapter:' branch
+        # for contains_keyword; the contains_indicator path is separate. The actual
+        # behaviour observed is that stripping occurs at file level for both modes.
+        # Verified: result is 2.
+        assert result == 2
+        assert isinstance(result, int)
+
+
+# ===========================================================================
+# get_subtitle_from_dash
+# ===========================================================================
+
+class TestGetSubtitleFromDash:
+    """Pin the behaviour of ``get_subtitle_from_dash``.
+
+    FLAG — default (replace=False) returns the SEPARATOR string (' - ' or ': '),
+    NOT the subtitle text itself.  Only with replace=True does it return the
+    subtitle portion after the separator.
+    """
+
+    # -----------------------------------------------------------------------
+    # replace=False (default) — returns SEPARATOR string
+    # -----------------------------------------------------------------------
+
+    def test_dash_separator_returns_separator_string(self):
+        """' - ' present → returns the literal separator ' - ', not the subtitle.
+
+        FLAG: replace=False returns the separator, not the text after it.
+        """
+        result = gsd("Series - Subtitle")
+        assert result == " - "
+
+    def test_colon_space_separator_returns_separator(self):
+        """'Series: Subtitle' → returns ': ' (the separator, not 'Subtitle')."""
+        result = gsd("Series: Subtitle")
+        assert result == ": "
+
+    def test_no_separator_returns_empty_string(self):
+        """Title with no recognisable separator → empty string."""
+        result = gsd("No subtitle here")
+        assert result == ""
+
+    def test_empty_string_returns_empty_string(self):
+        """Empty string → empty string."""
+        result = gsd("")
+        assert result == ""
+
+    def test_series_only_no_separator_returns_empty(self):
+        """Plain series name with no dash/colon → empty string."""
+        result = gsd("Series")
+        assert result == ""
+
+    def test_trailing_dash_still_returns_separator(self):
+        """'Series - ' (trailing whitespace after separator) → ' - '."""
+        result = gsd("Series - ")
+        assert result == " - "
+
+    def test_multiple_dashes_returns_first_separator(self):
+        """'A - B - C' → returns ' - ' (only the first occurrence is matched here)."""
+        result = gsd("A - B - C")
+        assert result == " - "
+
+    def test_colon_vol_dash_part_returns_first_separator(self):
+        """'Series: Vol 1 - Part 2' — colon comes first → ': '."""
+        result = gsd("Series: Vol 1 - Part 2")
+        assert result == ": "
+
+    def test_dash_without_spaces_no_match(self):
+        """'Series-Subtitle' (no spaces around dash) → empty string.
+
+        FLAG: the regex requires at least one whitespace before the dash:
+        ``(\\s+(-)|:)\\s+``.  A bare '-' without leading whitespace is not matched.
+        """
+        result = gsd("Series-Subtitle")
+        assert result == ""
+
+    def test_space_colon_no_space_after_no_match(self):
+        """'Series :Subtitle' (no space after colon) → empty string.
+
+        FLAG: the regex requires whitespace AFTER the separator (``\\s+``).
+        A colon without trailing whitespace is not matched.
+        """
+        result = gsd("Series :Subtitle")
+        assert result == ""
+
+    def test_space_colon_space_returns_separator(self):
+        """'Series : Subtitle' (spaces both sides of colon) → ': '."""
+        result = gsd("Series : Subtitle")
+        assert result == ": "
+
+    def test_dash_without_leading_space_no_match(self):
+        """'Series -Subtitle' (no space before dash) → empty string."""
+        result = gsd("Series -Subtitle")
+        assert result == ""
+
+    # -----------------------------------------------------------------------
+    # replace=True — returns SUBTITLE text (everything after the separator)
+    # -----------------------------------------------------------------------
+
+    def test_replace_true_dash_returns_subtitle(self):
+        """replace=True: 'Series - Subtitle' → 'Subtitle'."""
+        result = gsd("Series - Subtitle", replace=True)
+        assert result == "Subtitle"
+
+    def test_replace_true_colon_returns_subtitle(self):
+        """replace=True: 'Series: Subtitle' → 'Subtitle'."""
+        result = gsd("Series: Subtitle", replace=True)
+        assert result == "Subtitle"
+
+    def test_replace_true_no_separator_returns_empty(self):
+        """replace=True with no separator → empty string (no match → no replace)."""
+        result = gsd("No subtitle here", replace=True)
+        assert result == ""
+
+    def test_replace_true_empty_string_returns_empty(self):
+        """replace=True with empty string → empty string."""
+        result = gsd("", replace=True)
+        assert result == ""
+
+    def test_replace_true_trailing_dash(self):
+        """replace=True: 'Series - ' → empty string (nothing after the separator)."""
+        result = gsd("Series - ", replace=True)
+        assert result == ""
+
+    def test_replace_true_multiple_dashes(self):
+        """replace=True: 'A - B - C' — everything after the FIRST separator is kept.
+
+        The sub pattern ``r'(.*)((\\s+(-)|:)\\s+)'`` is greedy on the first group,
+        so it matches up to the LAST separator, leaving only 'C'.
+        """
+        result = gsd("A - B - C", replace=True)
+        assert result == "C"
+
+    def test_replace_true_colon_vol_dash_part(self):
+        """replace=True: 'Series: Vol 1 - Part 2' → 'Part 2'.
+
+        The greedy ``(.*)`` matches 'Series: Vol 1' consuming the colon separator,
+        then the second ``(\\s+(-)|:)\\s+`` matches ' - ', leaving 'Part 2'.
+        """
+        result = gsd("Series: Vol 1 - Part 2", replace=True)
+        assert result == "Part 2"
+
+    def test_replace_true_long_title(self):
+        """replace=True: 'My Long Series - A Great Subtitle' → 'A Great Subtitle'."""
+        result = gsd("My Long Series - A Great Subtitle", replace=True)
+        assert result == "A Great Subtitle"
+
+    def test_replace_true_space_colon_space(self):
+        """replace=True: 'Series : Subtitle' → 'Subtitle'."""
+        result = gsd("Series : Subtitle", replace=True)
+        assert result == "Subtitle"
+
+    def test_replace_true_dash_no_spaces_no_change(self):
+        """replace=True: 'Series-Subtitle' (no spaces around dash) → empty string.
+
+        No separator match → no substitution → '' returned.
+        """
+        result = gsd("Series-Subtitle", replace=True)
+        assert result == ""
+
+    def test_replace_true_vol_subtitle(self):
+        """replace=True: 'Series - Vol 1' → 'Vol 1'."""
+        result = gsd("Series - Vol 1", replace=True)
+        assert result == "Vol 1"
+
+
+# ===========================================================================
+# get_shortened_title
+# ===========================================================================
+
+class TestGetShortenedTitle:
+    """Pin the behaviour of ``get_shortened_title``.
+
+    Returns the part of the title BEFORE the first ' - ' or ': ' separator
+    (stripped of whitespace), or '' if no separator is present.
+    """
+
+    def test_dash_separator_returns_prefix(self):
+        """'Series - Subtitle' → 'Series'."""
+        result = gst("Series - Subtitle")
+        assert result == "Series"
+
+    def test_colon_space_separator_returns_prefix(self):
+        """'Series: Subtitle' → 'Series'."""
+        result = gst("Series: Subtitle")
+        assert result == "Series"
+
+    def test_no_separator_returns_empty_string(self):
+        """No separator → empty string (never None)."""
+        result = gst("No subtitle here")
+        assert result == ""
+
+    def test_plain_series_no_separator_returns_empty(self):
+        """Plain name without dash or colon → empty string."""
+        result = gst("Series")
+        assert result == ""
+
+    def test_multiple_dashes_returns_text_before_first(self):
+        """'A - B - C' — only the text before the FIRST separator is returned."""
+        result = gst("A - B - C")
+        assert result == "A"
+
+    def test_long_series_with_subtitle(self):
+        """'My Long Series - A Great Subtitle' → 'My Long Series'."""
+        result = gst("My Long Series - A Great Subtitle")
+        assert result == "My Long Series"
+
+    def test_colon_no_space_after_no_match(self):
+        """'Series:Subtitle' (colon without trailing space) → empty string.
+
+        FLAG: the regex ``r'((\\s+(-)|:)\\s+.*)'`` requires whitespace after the
+        colon.  A bare colon with no following space does not match.
+        """
+        result = gst("Series:Subtitle")
+        assert result == ""
+
+    def test_trailing_dash_separator(self):
+        """'Series - ' → 'Series' (nothing after the separator is OK)."""
+        result = gst("Series - ")
+        assert result == "Series"
+
+    def test_colon_space_subtitle(self):
+        """'Series: A Subtitle' → 'Series'."""
+        result = gst("Series: A Subtitle")
+        assert result == "Series"
+
+    def test_hyphenated_series_with_subtitle(self):
+        """'Spider-Man - Comic' — only the ' - ' (with spaces) triggers the split.
+
+        The bare hyphen in 'Spider-Man' has no spaces so is not a separator.
+        """
+        result = gst("Spider-Man - Comic")
+        assert result == "Spider-Man"
+
+    def test_hyphenated_series_no_subtitle(self):
+        """'Spider-Man' — only a hyphen without surrounding spaces → empty string."""
+        result = gst("Spider-Man")
+        assert result == ""
+
+    def test_leading_spaces_stripped(self):
+        """Leading whitespace in title does not affect matching; prefix is stripped."""
+        result = gst("  Series - Subtitle")
+        assert result == "Series"
+
+    def test_return_type_is_always_str(self):
+        """Return value is always str (never None), even when there is no match."""
+        assert isinstance(gst("NoSeparator"), str)
+        assert isinstance(gst("Has - Sep"), str)

--- a/tests/parsing/test_volume_keywords.py
+++ b/tests/parsing/test_volume_keywords.py
@@ -1,0 +1,516 @@
+"""Characterization tests for volume/chapter keyword detectors and one-shot/multi-volume checks.
+
+Functions under test (signatures verified via Serena + live execution):
+
+    kce.contains_volume_keywords(file: str) -> bool
+        @lru_cache(maxsize=3500)
+        Cleans the input (replaces ``_extra`` → ``.5``, strips brackets,
+        replaces underscores, removes dual spaces) and then applies
+        ``volume_regex`` (case-insensitive).
+
+    kce.contains_chapter_keywords(file_name: str) -> bool
+        @lru_cache(maxsize=3500)
+        Applies the six pre-compiled ``chapter_search_patterns_comp`` in order.
+        If none match AND the name has no volume keywords, falls back to a
+        positional numeric check (strips bracketed-year, then 2000-2999 suffix).
+
+    kce.is_one_shot(file_name, root=None, skip_folder_check=False, test_mode=False) -> bool
+        Returns True only when the name contains *no* volume keyword, *no* chapter
+        keyword, and *no* exception keyword.  test_mode=True implies
+        skip_folder_check=True so no directory access is needed.
+
+    kce.check_for_multi_volume_file(file_name: str, chapter: bool = False) -> bool
+        @lru_cache(maxsize=3500)
+        Looks for a ``KEYWORD n-m`` range pattern in the (bracket-stripped) name.
+        chapter=True appends the chapter regex keywords to the search.
+
+All values are OBSERVED from .venv/bin/python before being asserted.
+FLAG comments mark surprising/buggy behaviour pinned as-is.
+"""
+
+from __future__ import annotations
+
+import pytest
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# Helpers / aliases
+# ---------------------------------------------------------------------------
+
+def cvk(s: str) -> bool:
+    """Thin alias: contains_volume_keywords."""
+    return kce.contains_volume_keywords(s)
+
+
+def cck(s: str) -> bool:
+    """Thin alias: contains_chapter_keywords."""
+    return kce.contains_chapter_keywords(s)
+
+
+def ios(name: str, **kw) -> bool:
+    """Thin alias: is_one_shot (test_mode=True unless overridden)."""
+    kw.setdefault("test_mode", True)
+    return kce.is_one_shot(name, **kw)
+
+
+def cmvf(name: str, chapter: bool = False) -> bool:
+    """Thin alias: check_for_multi_volume_file."""
+    return kce.check_for_multi_volume_file(name, chapter)
+
+
+# ===========================================================================
+# contains_volume_keywords
+# ===========================================================================
+
+class TestContainsVolumeKeywords:
+    """Pin the boolean results of ``contains_volume_keywords``."""
+
+    # --- spec examples (straight from the task) ---
+
+    def test_spec_series_v01_cbz_true(self):
+        """Spec example: 'Series v01.cbz' → True."""
+        assert cvk("Series v01.cbz") is True
+
+    def test_spec_bare_001_false(self):
+        """Spec example: bare '001' (no keyword) → False."""
+        assert cvk("001") is False
+
+    # --- common volume keywords ---
+
+    def test_vol_dot_space_true(self):
+        """'Vol. 1' (with dot + space) → True."""
+        assert cvk("Series Vol. 1.cbz") is True
+
+    def test_volume_word_true(self):
+        """'Volume 1' spelled out → True."""
+        assert cvk("Series Volume 1.cbz") is True
+
+    def test_vol_no_dot_true(self):
+        """'Vol 2' without dot → True."""
+        assert cvk("Vol 2") is True
+
+    def test_uppercase_volume_true(self):
+        """'VOLUME 5' all-caps → True."""
+        assert cvk("VOLUME 5") is True
+
+    def test_v_prefix_bare_true(self):
+        """Bare 'v01' (no series name) → True."""
+        assert cvk("v01") is True
+
+    def test_ln_keyword_true(self):
+        """'LN 1' (light novel abbreviation) → True."""
+        assert cvk("Series LN 1") is True
+
+    def test_light_novel_keyword_true(self):
+        """'Light Novel 1' spelled out → True."""
+        assert cvk("Series Light Novel 1") is True
+
+    def test_novel_keyword_true(self):
+        """'Novel 1' → True."""
+        assert cvk("Series Novel 1") is True
+
+    def test_book_keyword_true(self):
+        """'Book 1' → True."""
+        assert cvk("Series Book 1") is True
+
+    def test_disc_keyword_true(self):
+        """'Disc 1' → True."""
+        assert cvk("Series Disc 1") is True
+
+    def test_tomo_keyword_true(self):
+        """'Tomo 1' (Spanish/Italian) → True."""
+        assert cvk("Series Tomo 1") is True
+
+    def test_tome_keyword_true(self):
+        """'Tome 1' (French) → True."""
+        assert cvk("Series Tome 1") is True
+
+    def test_t_prefix_true(self):
+        """'T01' (French manga 'Tome' abbreviation) → True."""
+        assert cvk("Series T01") is True
+
+    # --- underscore / bracket / _extra handling ---
+
+    def test_underscore_series_name_true(self):
+        """Underscores are replaced before regex → 'Series_v01.cbz' → True."""
+        assert cvk("Series_v01.cbz") is True
+
+    def test_extra_suffix_replaced_true(self):
+        """'_extra' is replaced with '.5' early; the volume keyword 'v01' survives → True."""
+        assert cvk("v01_extra") is True
+
+    def test_extra_suffix_with_series_true(self):
+        """'v01_extra' in a longer name still resolves → True."""
+        assert cvk("Series v01_extra.cbz") is True
+
+    def test_volume_in_square_brackets_false(self):
+        """FLAG: '[v01] Series.cbz' — bracket removal strips the ONLY volume token → False.
+
+        The code calls ``remove_brackets`` before applying volume_regex, so if the
+        volume keyword is *inside* brackets it is deleted and not detected.
+        This is surprising: a file that IS volume 1 returns False.
+        """
+        assert cvk("[v01] Series.cbz") is False
+
+    def test_volume_in_round_brackets_false(self):
+        """FLAG: 'Series (v01).cbz' — same bracket-removal quirk → False."""
+        assert cvk("Series (v01).cbz") is False
+
+    def test_volume_outside_brackets_with_extra_info_true(self):
+        """Keyword OUTSIDE brackets is preserved → 'Series v01 (special).cbz' → True."""
+        assert cvk("Series v01 (special).cbz") is True
+
+    def test_bare_v01_in_brackets_only_false(self):
+        """'[v01]' alone (keyword fully inside brackets) → False."""
+        assert cvk("[v01]") is False
+
+    # --- negative cases ---
+
+    def test_chapter_keyword_no_volume_false(self):
+        """'Chapter 001' has no volume keyword → False."""
+        assert cvk("Chapter 001") is False
+
+    def test_empty_string_false(self):
+        """Empty string → False."""
+        assert cvk("") is False
+
+    def test_whitespace_only_false(self):
+        """Whitespace-only string → False."""
+        assert cvk("   ") is False
+
+    def test_plain_series_name_false(self):
+        """Series name with no volume/chapter marker → False."""
+        assert cvk("Mushishi") is False
+
+    def test_tom_no_number_false(self):
+        """'Tom 1' is NOT in the keyword list (Tomo/Tome are; Tom is not) → False."""
+        assert cvk("Series Tom 1") is False
+
+
+# ===========================================================================
+# contains_chapter_keywords
+# ===========================================================================
+
+class TestContainsChapterKeywords:
+    """Pin the boolean results of ``contains_chapter_keywords``."""
+
+    # --- spec examples ---
+
+    def test_spec_series_c001_true(self):
+        """Spec example: 'Series c001' → True."""
+        assert cck("Series c001") is True
+
+    def test_spec_bare_001_true(self):
+        """Spec example: bare '001' → True (matches whole-string digit pattern)."""
+        assert cck("001") is True
+
+    def test_spec_100_true(self):
+        """Spec example: '100' → True."""
+        assert cck("100") is True
+
+    def test_spec_v01_false(self):
+        """Spec example: 'v01' has a volume keyword → False (vol check short-circuits)."""
+        assert cck("v01") is False
+
+    # --- chapter keyword variants ---
+
+    def test_chapter_spelled_out_true(self):
+        """'Chapter 5' (full word) → True."""
+        assert cck("Series Chapter 5") is True
+
+    def test_ch_dot_prefix_true(self):
+        """'ch.001' → True."""
+        assert cck("ch.001") is True
+
+    def test_ch_space_number_true(self):
+        """'Ch 5' (abbreviated, uppercase) → True."""
+        assert cck("Ch 5") is True
+
+    def test_c_space_number_true(self):
+        """'c 001' (single 'c' keyword with space) → True."""
+        assert cck("c 001") is True
+
+    def test_c1_no_space_true(self):
+        """'Series c1' → True."""
+        assert cck("Series c1") is True
+
+    def test_chapter_range_true(self):
+        """Multi-chapter range 'Series c01-05' → True."""
+        assert cck("Series c01-05") is True
+
+    # --- bare number edge cases ---
+
+    def test_bare_2000_true(self):
+        """Bare '2000' — despite looking like a year, the whole-string digit pattern
+        fires BEFORE the year-stripping fallback → True.
+
+        This is because ``chapter_search_patterns_comp[5]`` (^digits$) runs first.
+        """
+        assert cck("2000") is True
+
+    def test_bare_1999_true(self):
+        """Bare '1999' → True (same whole-string digit pattern)."""
+        assert cck("1999") is True
+
+    def test_bare_2999_true(self):
+        """Bare '2999' → True."""
+        assert cck("2999") is True
+
+    def test_bare_3000_true(self):
+        """Bare '3000' → True."""
+        assert cck("3000") is True
+
+    # --- 4-digit bracketed number is filtered (year-like) ---
+
+    def test_four_digit_round_brackets_false(self):
+        """FLAG: '(1234)' — the code explicitly skips 4-digit values wrapped in
+        a single bracket pair to avoid treating years as chapter numbers → False."""
+        assert cck("(1234)") is False
+
+    def test_four_digit_square_brackets_false(self):
+        """'[1234]' — same 4-digit bracket filter applies → False."""
+        assert cck("[1234]") is False
+
+    def test_four_digit_curly_brackets_false(self):
+        """'{1234}' — same 4-digit bracket filter applies → False."""
+        assert cck("{1234}") is False
+
+    def test_three_digit_round_brackets_true(self):
+        """'(123)' — only 3 digits, bracket filter doesn't apply → True."""
+        assert cck("(123)") is True
+
+    def test_five_digit_round_brackets_true(self):
+        """'(12345)' — 5 digits, bracket filter doesn't apply → True."""
+        assert cck("(12345)") is True
+
+    # --- interaction with volume keywords ---
+
+    def test_volume_keyword_blocks_chapter_fallback_false(self):
+        """'v01 2000' has a volume keyword; the numeric fallback is skipped → False."""
+        assert cck("v01 2000") is False
+
+    def test_series_vol_with_year_in_brackets_false(self):
+        """'Series v01 (2020).cbz' — volume keyword present → False."""
+        assert cck("Series v01 (2020).cbz") is False
+
+    def test_series_year_only_in_brackets_false(self):
+        """'Series (2020).cbz' — no chapter keyword; bracketed 4-digit filtered → False."""
+        assert cck("Series (2020).cbz") is False
+
+    # --- negative cases ---
+
+    def test_empty_string_false(self):
+        """Empty string → False."""
+        assert cck("") is False
+
+    def test_volume_keyword_only_false(self):
+        """'v01' → False (volume present, no chapter indicator, fallback not triggered)."""
+        assert cck("v01") is False
+
+    def test_vol_plus_chapter_series_true(self):
+        """'Series v01 c001' contains BOTH a volume and a chapter keyword.
+        The chapter keyword patterns run first and find 'c001' → True.
+        """
+        assert cck("Series v01 c001") is True
+
+
+# ===========================================================================
+# is_one_shot
+# ===========================================================================
+
+class TestIsOneShot:
+    """Pin the boolean results of ``is_one_shot`` (always called with test_mode=True)."""
+
+    # --- one-shot positives: no volume, no chapter, no exception keyword ---
+
+    def test_plain_filename_true(self):
+        """Plain filename with no markers → True (is a one-shot)."""
+        assert ios("My Manga.cbz") is True
+
+    def test_bare_title_true(self):
+        """Famous standalone title → True."""
+        assert ios("Mushishi.cbz") is True
+
+    def test_empty_string_true(self):
+        """FLAG: empty string → True.
+
+        No keywords match → skip_folder_check is True (via test_mode) → returns True.
+        An empty filename being classified as a one-shot is unexpected.
+        """
+        assert ios("") is True
+
+    # --- volume keyword → False ---
+
+    def test_volume_keyword_false(self):
+        """Volume marker 'v01' → False."""
+        assert ios("Series v01.cbz") is False
+
+    def test_volume_word_false(self):
+        """'Volume 1' spelled out → False."""
+        assert ios("Series Volume 1.cbz") is False
+
+    # --- chapter keyword → False ---
+
+    def test_chapter_keyword_false(self):
+        """Chapter marker 'c001' → False."""
+        assert ios("Series c001.cbz") is False
+
+    def test_chapter_spelled_out_false(self):
+        """'Chapter 1' spelled out → False."""
+        assert ios("Series Chapter 1.cbz") is False
+
+    def test_bare_number_false(self):
+        """Bare '001.cbz' → False (contains_chapter_keywords('001') is True)."""
+        assert ios("001.cbz") is False
+
+    # --- exception keywords → False ---
+
+    def test_oneshot_hyphen_false(self):
+        """'One-shot' (hyphenated) matches exception pattern 'Ones?(-|)shot' → False."""
+        assert ios("Series One-shot.cbz") is False
+
+    def test_oneshot_no_separator_false(self):
+        """'Oneshot' (no separator) matches exception pattern → False."""
+        assert ios("Series Oneshot.cbz") is False
+
+    def test_omake_false(self):
+        """'Omake' matches exception keyword → False."""
+        assert ios("Series Omake.cbz") is False
+
+    def test_special_false(self):
+        """'Special' matches exception keyword → False."""
+        assert ios("Series Special.cbz") is False
+
+    def test_extra_false(self):
+        """'Extra' matches exception keyword → False."""
+        assert ios("Series Extra.cbz") is False
+
+    def test_bonus_false(self):
+        """'Bonus' matches exception keyword → False."""
+        assert ios("Series Bonus.cbz") is False
+
+    def test_side_story_hyphen_false(self):
+        """'Side-story' matches exception keyword → False."""
+        assert ios("Series Side-story.cbz") is False
+
+    def test_one_shot_space_does_not_match_false(self):
+        """FLAG: 'One Shot' with a SPACE does NOT match the exception keyword
+        pattern 'Ones?(-|)shot' (pattern allows hyphen or empty, not space).
+        So the file is treated as a normal one-shot → True.
+
+        This is a latent bug: a file literally named 'One Shot' is not recognised
+        as an exception keyword file.
+        """
+        assert ios("My Manga - One Shot.cbz") is True
+
+    # --- test_mode vs skip_folder_check equivalence ---
+
+    def test_skip_folder_check_same_as_test_mode(self):
+        """skip_folder_check=True (no root supplied) gives same result as test_mode=True."""
+        assert kce.is_one_shot("My Manga.cbz", skip_folder_check=True) is True
+        assert kce.is_one_shot("Series v01.cbz", skip_folder_check=True) is False
+
+
+# ===========================================================================
+# check_for_multi_volume_file
+# ===========================================================================
+
+class TestCheckForMultiVolumeFile:
+    """Pin the boolean results of ``check_for_multi_volume_file``."""
+
+    # --- spec examples ---
+
+    def test_spec_v01_03_true(self):
+        """Spec example: 'Series v01-03.cbz' → True."""
+        assert cmvf("Series v01-03.cbz") is True
+
+    def test_spec_v01_v03_false(self):
+        """FLAG spec example: 'Series v01-v03.cbz' → False.
+
+        The regex expects ``KEYWORD number - number``; when the second segment
+        also has a keyword prefix ('v03'), the pattern does not match. So a file
+        that IS a multi-volume range is mis-classified as False.
+        This is pinned as-is; do not 'fix' production code here.
+        """
+        assert cmvf("Series v01-v03.cbz") is False
+
+    # --- single volume → False ---
+
+    def test_single_volume_false(self):
+        """Single volume 'v01' (no range) → False."""
+        assert cmvf("Series v01.cbz") is False
+
+    def test_bare_v01_false(self):
+        """Bare 'v01' token → False."""
+        assert cmvf("v01") is False
+
+    def test_no_dash_false(self):
+        """No dash in name → False (short-circuits before regex)."""
+        assert cmvf("Series Vol. 1.cbz") is False
+
+    # --- successful multi-volume detections ---
+
+    def test_vol_dot_range_true(self):
+        """'Vol. 1-3' → True."""
+        assert cmvf("Series Vol. 1-3.cbz") is True
+
+    def test_decimal_start_range_true(self):
+        """'Vol 1.5-3' (decimal start) → True."""
+        assert cmvf("Series Vol 1.5-3.cbz") is True
+
+    def test_decimal_end_range_true(self):
+        """'Vol 1-3.5' (decimal end) → True."""
+        assert cmvf("Series Vol 1-3.5.cbz") is True
+
+    def test_three_part_range_true(self):
+        """'v01-02-03' (3+ consecutive volumes) → True."""
+        assert cmvf("Series v01-02-03.cbz") is True
+
+    def test_no_volume_keyword_range_false(self):
+        """'Series 1-3.cbz' has no volume keyword → False (keyword required)."""
+        assert cmvf("Series 1-3.cbz") is False
+
+    # --- bracket stripping behaviour ---
+
+    def test_range_inside_brackets_false(self):
+        """FLAG: '[v01-03]' — bracket removal erases the range; nothing left to match → False.
+
+        This mirrors the same bracket-stripping issue seen in ``contains_volume_keywords``.
+        A multi-volume range that lives entirely inside brackets is not detected.
+        """
+        assert cmvf("Series [v01-03].cbz") is False
+
+    # --- chapter=True mode ---
+
+    def test_chapter_flag_c_range_true(self):
+        """chapter=True: 'c001-005.cbz' → True (chapter keywords added to search)."""
+        assert cmvf("c001-005.cbz", True) is True
+
+    def test_chapter_flag_c_range_false_without_flag(self):
+        """chapter=False (default): 'c001-005.cbz' → False (chapter keyword not searched)."""
+        assert cmvf("c001-005.cbz", False) is False
+
+    def test_chapter_flag_chapter_spelled_out_true(self):
+        """chapter=True: 'Chapter 1-5' → True."""
+        assert cmvf("Series Chapter 1-5.cbz", True) is True
+
+    def test_chapter_flag_chapter_spelled_out_false_without_flag(self):
+        """chapter=False: 'Chapter 1-5' → False (not treated as a volume range)."""
+        assert cmvf("Series Chapter 1-5.cbz", False) is False
+
+    def test_chapter_short_c1_range_true(self):
+        """chapter=True: 'c1-3.cbz' (short form) → True."""
+        assert cmvf("c1-3.cbz", True) is True
+
+    # --- no-keyword number range (requires chapter flag) ---
+
+    def test_volume_range_with_chapter_flag_false(self):
+        """FLAG: chapter=True replaces the keyword set with ONLY chapter keywords
+        (``chapter_regex_keywords + '|'``), so a volume-keyword range like
+        'Series v01-03.cbz' is NOT detected → False.
+
+        This means check_for_multi_volume_file(name, chapter=True) cannot detect
+        volume ranges — it is a chapter-only search when the flag is set.
+        """
+        assert cmvf("Series v01-03.cbz", True) is False

--- a/tests/regression_gate.py
+++ b/tests/regression_gate.py
@@ -1,0 +1,151 @@
+"""Regression gate for the legacy ``tests.py`` custom runner.
+
+``tests.py`` is a bespoke assertion runner (NOT pytest): bare ``assert``s in
+``test_*()`` functions, called in sequence under ``if __name__ == "__main__"``.
+The runner HALTS on the first failing assert, so a single break masks every test
+after it. To detect regressions reliably we instead run **every** ``test_*``
+function INDEPENDENTLY (each in its own fresh Python process, exactly as
+CLAUDE.md documents: ``python3 -c "import tests; tests.test_clean_str()"``).
+
+Baseline on ``library-replacements`` with default ``settings.py``:
+**35 pass / 4 fail**, where the 4 failures are KNOWN and are NOT regressions:
+
+  * ``test_get_extra_from_group``   — commented out in the legacy runner
+  * ``test_get_keyword_score``      — commented out in the legacy runner
+  * ``test_remove_ignored_folders`` — settings-dependent (default settings make it fail)
+  * ``test_has_multiple_numbers``   — pre-existing assertion failure
+
+This module exposes :func:`run_gate` (used by both the CLI ``__main__`` here and
+by ``tests/test_legacy_regression.py``) which returns a structured result and
+raises ``AssertionError`` if ANY new failure appears or any expected-pass test
+regresses. Run directly:
+
+    .venv/bin/python tests/regression_gate.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+# Repo root = parent of this tests/ directory. The legacy suite must be imported
+# with the repo root as cwd so that `import komga_cover_extractor` / `settings`
+# resolve.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The 4 known-failing tests that are NOT regressions (see module docstring).
+KNOWN_FAILURES = frozenset(
+    {
+        "test_get_extra_from_group",
+        "test_get_keyword_score",
+        "test_remove_ignored_folders",
+        "test_has_multiple_numbers",
+    }
+)
+
+EXPECTED_PASS = 35
+EXPECTED_FAIL = 4
+
+
+def discover_legacy_tests() -> list[str]:
+    """Return the sorted names of every ``test_*`` function defined in tests.py."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import tests; print('\\n'.join(n for n in dir(tests) "
+            "if n.startswith('test_')))",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "Failed to import legacy tests.py for discovery:\n" + proc.stderr
+        )
+    return sorted(n for n in proc.stdout.split() if n.startswith("test_"))
+
+
+def _run_one(name: str) -> tuple[bool, str]:
+    """Run a single legacy test in a fresh process. Returns (passed, output)."""
+    proc = subprocess.run(
+        [sys.executable, "-c", f"import tests; tests.{name}()"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    return proc.returncode == 0, (proc.stdout + proc.stderr)
+
+
+def run_gate(verbose: bool = True) -> dict:
+    """Run every legacy test independently and validate against the baseline.
+
+    Returns a dict with keys: passed, failed, new_failures, unexpected_passes,
+    details. Raises AssertionError if the baseline is violated (new regressions
+    or an expected-pass test that now fails / an expected-fail that now passes
+    in a way that shifts the count).
+    """
+    names = discover_legacy_tests()
+    passed: list[str] = []
+    failed: list[str] = []
+    details: dict[str, str] = {}
+
+    for name in names:
+        ok, output = _run_one(name)
+        if ok:
+            passed.append(name)
+        else:
+            failed.append(name)
+            details[name] = output.strip()[-2000:]
+
+    failed_set = set(failed)
+    new_failures = sorted(failed_set - KNOWN_FAILURES)
+    # Expected-fail tests that unexpectedly passed (baseline drift the other way).
+    unexpected_passes = sorted(KNOWN_FAILURES - failed_set)
+
+    result = {
+        "total": len(names),
+        "passed": len(passed),
+        "failed": len(failed),
+        "new_failures": new_failures,
+        "unexpected_passes": unexpected_passes,
+        "details": details,
+    }
+
+    if verbose:
+        print(f"Legacy regression gate: {len(passed)} pass / {len(failed)} fail "
+              f"(of {len(names)} total)")
+        if new_failures:
+            print("  NEW FAILURES (regressions):")
+            for n in new_failures:
+                print(f"    - {n}")
+                print("      " + details[n].replace("\n", "\n      "))
+        if unexpected_passes:
+            print("  Unexpectedly PASSING (were known-fail):", unexpected_passes)
+
+    assert not new_failures, (
+        f"Regression detected: {new_failures} newly failing "
+        f"(baseline allows only {sorted(KNOWN_FAILURES)})"
+    )
+    assert not unexpected_passes, (
+        f"Known-fail tests now pass: {unexpected_passes}. The baseline shifted; "
+        f"update KNOWN_FAILURES in tests/regression_gate.py if this is intended."
+    )
+    assert result["passed"] == EXPECTED_PASS, (
+        f"Expected {EXPECTED_PASS} passing legacy tests, got {result['passed']}"
+    )
+    assert result["failed"] == EXPECTED_FAIL, (
+        f"Expected {EXPECTED_FAIL} failing legacy tests, got {result['failed']}"
+    )
+    return result
+
+
+if __name__ == "__main__":
+    try:
+        run_gate(verbose=True)
+    except AssertionError as exc:
+        print("GATE FAILED:", exc)
+        sys.exit(1)
+    print("GATE OK: 35 pass / 4 known-fail / 0 new regressions")

--- a/tests/similarity/test_similar.py
+++ b/tests/similarity/test_similar.py
@@ -1,0 +1,228 @@
+"""Characterization tests for kce.similar(a, b).
+
+``similar`` is a rapidfuzz Indel.normalized_similarity wrapper decorated with
+@lru_cache(maxsize=3500).  It lower-cases and strips both inputs before
+comparing, and short-circuits to 0.0 when either stripped value is empty or to
+1.0 when they are equal.
+
+All expected values below were pinned by running::
+
+    .venv/bin/python -c "import komga_cover_extractor as kce; print(repr(kce.similar(A, B)))"
+
+and recording the exact float returned by the running interpreter.
+"""
+
+from __future__ import annotations
+
+import pytest
+import komga_cover_extractor as kce
+
+
+# --------------------------------------------------------------------------- #
+# Helper — exact-float equality only where the value is a clean 1.0 or 0.0.
+# For irrational-looking floats we use pytest.approx with a tight tolerance
+# to guard against any floating-point noise across Python patch releases.
+# --------------------------------------------------------------------------- #
+
+_APPROX = pytest.approx  # re-exported for brevity in parametrize
+
+
+# --------------------------------------------------------------------------- #
+# 1. Spec cases (from the task description)
+# --------------------------------------------------------------------------- #
+
+class TestSpecCases:
+    """Pin the explicit examples stated in the task specification."""
+
+    def test_identical_strings(self):
+        """identical 'hello'/'hello' -> 1.0"""
+        assert kce.similar("hello", "hello") == 1.0
+
+    def test_case_insensitive(self):
+        """'HELLO'/'hello' -> 1.0 (both lowercased before compare)"""
+        assert kce.similar("HELLO", "hello") == 1.0
+
+    def test_empty_left(self):
+        """'' vs anything -> 0.0 (early-exit guard)"""
+        assert kce.similar("", "hello") == 0.0
+
+    def test_empty_right(self):
+        """anything vs '' -> 0.0 (early-exit guard)"""
+        assert kce.similar("hello", "") == 0.0
+
+    def test_both_empty(self):
+        """'' vs '' -> 0.0 (empty check fires before equality check)"""
+        # FLAG: both empty returns 0.0, not 1.0 — the empty guard runs first.
+        assert kce.similar("", "") == 0.0
+
+    def test_abc_abcd(self):
+        """'abc'/'abcd' -> 0.8571428571428572"""
+        result = kce.similar("abc", "abcd")
+        assert result == _APPROX(0.8571428571428572, rel=1e-9)
+
+    def test_abc_xyz(self):
+        """'abc'/'xyz' -> 0.0 (no common characters at Indel distance)"""
+        assert kce.similar("abc", "xyz") == 0.0
+
+    def test_whitespace_stripped(self):
+        """'  hello  '/'hello' -> 1.0 (strip() normalizes leading/trailing space)"""
+        assert kce.similar("  hello  ", "hello") == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# 2. Case-normalization edge cases
+# --------------------------------------------------------------------------- #
+
+class TestCaseNormalization:
+    """Verify all-caps, mixed-case, and tab/newline stripping behavior."""
+
+    def test_mixed_case_manga(self):
+        """'MaNgA'/'manga' -> 1.0"""
+        assert kce.similar("MaNgA", "manga") == 1.0
+
+    def test_all_caps_vs_lower(self):
+        """'ABC'/'abc' -> 1.0 (case fold)"""
+        assert kce.similar("ABC", "abc") == 1.0
+
+    def test_tab_padding_stripped(self):
+        """\thello\t vs hello -> 1.0 (strip removes tabs)"""
+        assert kce.similar("\thello\t", "hello") == 1.0
+
+    def test_newline_trailing_stripped(self):
+        """'hello\\n' vs 'hello' -> 1.0 (strip removes newline)"""
+        assert kce.similar("hello\n", "hello") == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# 3. Single-character pairs
+# --------------------------------------------------------------------------- #
+
+class TestSingleCharacter:
+    """Pin behavior for length-1 inputs; illustrates the 0.0 floor for a/b."""
+
+    def test_same_char(self):
+        """'a'/'a' -> 1.0"""
+        assert kce.similar("a", "a") == 1.0
+
+    def test_different_chars(self):
+        """'a'/'b' -> 0.0 (Indel distance = 2 over total length 2)"""
+        assert kce.similar("a", "b") == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# 4. Near-identical strings (small edit distance)
+# --------------------------------------------------------------------------- #
+
+class TestNearIdentical:
+    """Pin floats for strings with only one or two character differences."""
+
+    def test_ab_abc(self):
+        """'ab'/'abc' -> 0.8"""
+        assert kce.similar("ab", "abc") == _APPROX(0.8, rel=1e-9)
+
+    def test_abc_ab(self):
+        """'abc'/'ab' -> 0.8 (symmetric)"""
+        assert kce.similar("abc", "ab") == _APPROX(0.8, rel=1e-9)
+
+    def test_numeric_123_1234(self):
+        """'123'/'1234' -> same ratio as abc/abcd"""
+        assert kce.similar("123", "1234") == _APPROX(0.8571428571428572, rel=1e-9)
+
+    def test_sword_art_online_offline(self):
+        """'sword art online'/'sword art offline' -> ~0.909"""
+        result = kce.similar("sword art online", "sword art offline")
+        assert result == _APPROX(0.9090909090909091, rel=1e-9)
+
+    def test_hello_world_exclaim(self):
+        """'hello world'/'hello world!' -> ~0.957"""
+        result = kce.similar("hello world", "hello world!")
+        assert result == _APPROX(0.9565217391304348, rel=1e-9)
+
+    def test_long_prefix_match(self):
+        """'the quick brown fox'/'the quick brown fox jumps' -> ~0.864"""
+        result = kce.similar("the quick brown fox", "the quick brown fox jumps")
+        assert result == _APPROX(0.8636363636363636, rel=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 5. Partial / substring overlaps
+# --------------------------------------------------------------------------- #
+
+class TestPartialOverlap:
+    """Pairs where one string is a substring of the other, or overlap partially."""
+
+    def test_one_piece_volume(self):
+        """'one piece'/'one piece vol 1' -> 0.75"""
+        assert kce.similar("one piece", "one piece vol 1") == _APPROX(0.75, rel=1e-9)
+
+    def test_numeric_identical(self):
+        """'123'/'123' -> 1.0"""
+        assert kce.similar("123", "123") == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# 6. Completely dissimilar strings
+# --------------------------------------------------------------------------- #
+
+class TestDissimilar:
+    """Pin non-zero but low similarity for strings sharing few/no characters."""
+
+    def test_completely_different(self):
+        """'completely'/'different' -> ~0.211"""
+        result = kce.similar("completely", "different")
+        assert result == _APPROX(0.21052631578947367, rel=1e-9)
+
+    def test_hello_world(self):
+        """'hello'/'world' -> ~0.2 (small shared characters via Indel)"""
+        result = kce.similar("hello", "world")
+        assert result == _APPROX(0.19999999999999996, rel=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 7. Anagram / transposition pairs (Indel is NOT edit-distance symmetric here)
+# --------------------------------------------------------------------------- #
+
+class TestTranspositions:
+    """Indel distance penalises transpositions as two separate operations."""
+
+    def test_ab_ba(self):
+        """'ab'/'ba' -> 0.5 (two single-char edits over total 4)"""
+        assert kce.similar("ab", "ba") == _APPROX(0.5, rel=1e-9)
+
+    def test_abc_bca(self):
+        """'abc'/'bca' -> ~0.667"""
+        result = kce.similar("abc", "bca")
+        assert result == _APPROX(0.6666666666666667, rel=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 8. Return-type and lru_cache meta checks
+# --------------------------------------------------------------------------- #
+
+class TestMeta:
+    """Verify that the function contract (float return, lru_cache) is intact."""
+
+    def test_returns_float(self):
+        """similar always returns float, not int or other numeric type."""
+        result = kce.similar("hello", "hello")
+        assert isinstance(result, float)
+
+    def test_returns_float_for_partial(self):
+        """Partial-match result is also a float."""
+        result = kce.similar("abc", "abcd")
+        assert isinstance(result, float)
+
+    def test_lru_cache_present(self):
+        """similar must be wrapped by lru_cache (has .cache_info attribute)."""
+        assert hasattr(kce.similar, "cache_info")
+
+    def test_lru_cache_maxsize(self):
+        """lru_cache maxsize is pinned to 3500 as declared in source."""
+        info = kce.similar.cache_info()
+        assert info.maxsize == 3500
+
+    def test_deterministic_repeated_calls(self):
+        """Multiple calls with same args return identical value (cache consistency)."""
+        first = kce.similar("manga", "manga series")
+        second = kce.similar("manga", "manga series")
+        assert first == second

--- a/tests/test_legacy_regression.py
+++ b/tests/test_legacy_regression.py
@@ -1,0 +1,20 @@
+"""Pytest wrapper around the legacy tests.py regression gate.
+
+Runs the full legacy suite (each test independently, in fresh processes) and
+asserts the 35-pass / 4-known-fail / 0-new-regression baseline. Marked ``slow``
+because it spawns ~39 subprocesses, each importing the 12k-line module; opt out
+with ``-m "not slow"`` during fast iteration.
+"""
+
+import pytest
+
+from regression_gate import EXPECTED_FAIL, EXPECTED_PASS, run_gate
+
+
+@pytest.mark.slow
+def test_legacy_suite_baseline():
+    result = run_gate(verbose=True)
+    assert result["passed"] == EXPECTED_PASS
+    assert result["failed"] == EXPECTED_FAIL
+    assert result["new_failures"] == []
+    assert result["unexpected_passes"] == []

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,56 @@
+"""PR1 smoke tests: prove the harness is wired up and pin two conftest contracts.
+
+These are intentionally trivial. Their job is to fail loudly if the module
+won't import, if a fixture is broken, or if a foundational assumption the rest
+of the suite relies on (lru-cache introspection, Volume identity-equality)
+changes.
+"""
+
+import komga_cover_extractor as kce
+from _kce_support import lru_cached_callables
+
+
+def test_module_imports():
+    """The single-file app imports cleanly under the test harness."""
+    assert kce is not None
+    assert hasattr(kce, "main")
+    assert hasattr(kce, "Volume")
+
+
+def test_similar_identity():
+    """similar() returns 1.0 for identical strings (rapidfuzz swap sanity)."""
+    assert kce.similar("a", "a") == 1.0
+
+
+def test_set_num_as_float_or_int_basic():
+    """A representative pure-util call returns the expected scalar."""
+    assert kce.set_num_as_float_or_int("1") == 1
+
+
+def test_lru_cache_introspection_nonempty():
+    """The runtime lru-cache list (used by isolated_globals) is non-empty.
+
+    If this drops to zero, the autouse cache-clearing fixture has silently
+    stopped clearing anything and cross-test cache bleed becomes possible.
+    """
+    cached = lru_cached_callables()
+    assert len(cached) >= 20, f"expected many lru_cache fns, got {len(cached)}"
+    # similar and clean_str are known cached members.
+    names = {fn.__name__ for fn in cached}
+    assert "similar" in names
+    assert "clean_str" in names
+
+
+def test_volume_has_no_eq_uses_identity():
+    """FLAG/contract: kce.Volume has no __eq__, so == is identity comparison.
+
+    Documented so nobody writes `assert vol_a == vol_b` expecting field
+    comparison. If a __eq__ is ever added, this test fails and forces a review
+    of every equality assertion in the suite.
+    """
+    assert "__eq__" not in vars(kce.Volume)
+    # Two distinct instances with identical args are NOT equal (identity).
+    a = kce.File("n", "n", "b", ".cbz", "/r", "/r/n.cbz", "/r/n", 1, "volume", ".cbz")
+    b = kce.File("n", "n", "b", ".cbz", "/r", "/r/n.cbz", "/r/n", 1, "volume", ".cbz")
+    assert a is not b
+    assert (a == b) is False

--- a/tests/utils/test_number_utils.py
+++ b/tests/utils/test_number_utils.py
@@ -1,0 +1,534 @@
+"""Characterization tests for number-related utility functions.
+
+Every assertion was verified against the live module BEFORE writing:
+    .venv/bin/python -c "import komga_cover_extractor as kce; print(repr(kce.FUNC(ARGS)))"
+
+Surprising / buggy behavior is noted with a ``# FLAG:`` comment and pinned AS-IS.
+
+Functions covered (all from komga_cover_extractor.py):
+    set_num_as_float_or_int, isfloat, isint, get_min_and_max_numbers,
+    complete_num_array, abbreviate_numbers, has_one_set_of_numbers,
+    contains_non_numeric, extract_all_numbers, has_multiple_numbers
+"""
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# set_num_as_float_or_int
+# ---------------------------------------------------------------------------
+
+def test_set_num_as_float_or_int_integer_string_returns_int():
+    # '1' -> 1 (int type)
+    result = kce.set_num_as_float_or_int("1")
+    assert result == 1
+    assert isinstance(result, int)
+
+
+def test_set_num_as_float_or_int_float_string_returns_float():
+    # '1.5' -> 1.5 (float)
+    result = kce.set_num_as_float_or_int("1.5")
+    assert result == 1.5
+    assert isinstance(result, float)
+
+
+def test_set_num_as_float_or_int_dot_zero_returns_float():
+    # FLAG: '2.0' short-circuits into the `elif '.' in volume_number` branch and
+    # returns float(2.0) WITHOUT the int-equality check. It is a float, not int.
+    result = kce.set_num_as_float_or_int("2.0")
+    assert result == 2.0
+    assert isinstance(result, float)
+
+
+def test_set_num_as_float_or_int_ten_dot_zero_returns_float():
+    # Same short-circuit: '10.0' -> 10.0 (float)
+    result = kce.set_num_as_float_or_int("10.0")
+    assert result == 10.0
+    assert isinstance(result, float)
+
+
+def test_set_num_as_float_or_int_empty_string_returns_empty():
+    assert kce.set_num_as_float_or_int("") == ""
+
+
+def test_set_num_as_float_or_int_int_list_returns_hyphen_joined_string():
+    # FLAG: a list of ints/floats is joined with '-' and returned as a STRING,
+    # not converted to any numeric type.
+    result = kce.set_num_as_float_or_int([1, 2, 3])
+    assert result == "1-2-3"
+    assert isinstance(result, str)
+
+
+def test_set_num_as_float_or_int_str_list_returns_hyphen_joined_string():
+    # FLAG: a list of numeric strings is also joined with '-' as a STRING.
+    result = kce.set_num_as_float_or_int(["1", "3"])
+    assert result == "1-3"
+    assert isinstance(result, str)
+
+
+def test_set_num_as_float_or_int_float_list_returns_hyphen_joined_string():
+    # [1.5, 2.5] -> '1.5-2.5' (floats, no int-equality applied to elements)
+    result = kce.set_num_as_float_or_int([1.5, 2.5])
+    assert result == "1.5-2.5"
+    assert isinstance(result, str)
+
+
+def test_set_num_as_float_or_int_float_str_list_returns_hyphen_joined_string():
+    result = kce.set_num_as_float_or_int(["1.5", "2.5"])
+    assert result == "1.5-2.5"
+    assert isinstance(result, str)
+
+
+def test_set_num_as_float_or_int_invalid_silent_returns_empty():
+    # 'abc' with silent=True -> '' (suppresses send_message side-effect)
+    assert kce.set_num_as_float_or_int("abc", silent=True) == ""
+
+
+def test_set_num_as_float_or_int_large_integer():
+    result = kce.set_num_as_float_or_int("10")
+    assert result == 10
+    assert isinstance(result, int)
+
+
+def test_set_num_as_float_or_int_zero_integer():
+    result = kce.set_num_as_float_or_int("0")
+    assert result == 0
+    assert isinstance(result, int)
+
+
+def test_set_num_as_float_or_int_half():
+    result = kce.set_num_as_float_or_int("0.5")
+    assert result == 0.5
+    assert isinstance(result, float)
+
+
+def test_set_num_as_float_or_int_native_int_passthrough():
+    # Native int 5 goes through else branch: float(5)==int(5) -> int 5
+    result = kce.set_num_as_float_or_int(5)
+    assert result == 5
+    assert isinstance(result, int)
+
+
+# ---------------------------------------------------------------------------
+# isfloat
+# ---------------------------------------------------------------------------
+
+def test_isfloat_decimal_string():
+    assert kce.isfloat("3.14") is True
+
+
+def test_isfloat_integer_string():
+    # '3' converts to float -> True
+    assert kce.isfloat("3") is True
+
+
+def test_isfloat_alpha_string():
+    assert kce.isfloat("abc") is False
+
+
+def test_isfloat_none():
+    assert kce.isfloat(None) is False
+
+
+def test_isfloat_empty_string():
+    assert kce.isfloat("") is False
+
+
+def test_isfloat_native_float():
+    assert kce.isfloat(3.14) is True
+
+
+def test_isfloat_zero_int():
+    assert kce.isfloat(0) is True
+
+
+def test_isfloat_scientific_notation():
+    # '1e2' -> float(1e2)=100.0 -> True
+    assert kce.isfloat("1e2") is True
+
+
+# ---------------------------------------------------------------------------
+# isint
+# ---------------------------------------------------------------------------
+
+def test_isint_integer_string():
+    assert kce.isint("3") is True
+
+
+def test_isint_dot_zero_string():
+    # '3.0' -> float(3.0)==int(3) -> True
+    assert kce.isint("3.0") is True
+
+
+def test_isint_decimal_string():
+    # '3.5' -> float(3.5) != int(3) -> False
+    assert kce.isint("3.5") is False
+
+
+def test_isint_alpha_string():
+    assert kce.isint("abc") is False
+
+
+def test_isint_empty_string():
+    assert kce.isint("") is False
+
+
+def test_isint_native_int():
+    assert kce.isint(3) is True
+
+
+def test_isint_native_float_whole():
+    # 3.0 -> float(3.0)==int(3) -> True
+    assert kce.isint(3.0) is True
+
+
+def test_isint_negative_integer_string():
+    assert kce.isint("-1") is True
+
+
+def test_isint_zero_string():
+    assert kce.isint("0") is True
+
+
+def test_isint_none():
+    assert kce.isint(None) is False
+
+
+def test_isint_scientific_notation():
+    # '1e2' -> float(100.0)==int(100) -> True
+    assert kce.isint("1e2") is True
+
+
+# ---------------------------------------------------------------------------
+# get_min_and_max_numbers
+# ---------------------------------------------------------------------------
+
+def test_get_min_and_max_numbers_range():
+    # '1-3' -> split on hyphen -> [1, 3]
+    assert kce.get_min_and_max_numbers("1-3") == [1, 3]
+
+
+def test_get_min_and_max_numbers_reversed_is_sorted():
+    # '3-1' -> min=1, max=3 -> [1, 3]  (sorted, not original order)
+    assert kce.get_min_and_max_numbers("3-1") == [1, 3]
+
+
+def test_get_min_and_max_numbers_invalid_silent():
+    # FLAG: 'abc-def' -> each token fails conversion -> set_num_as_float_or_int
+    # returns '' for each -> numbers_search becomes ['', ''] -> min(['', ''])
+    # returns '' -> result is [''] (list of empty string, NOT empty list)
+    # (We pass the string as-is; the function calls send_message internally, but
+    # since this is a characterization test we accept the side-effect output.)
+    result = kce.get_min_and_max_numbers("abc-def")
+    assert result == [""]
+
+
+def test_get_min_and_max_numbers_single_number():
+    # '5' -> [5] (no max appended when only one element)
+    assert kce.get_min_and_max_numbers("5") == [5]
+
+
+def test_get_min_and_max_numbers_three_numbers_keeps_min_max():
+    # '2-5-8' -> min=2, max=8 -> [2, 8]  (middle value discarded)
+    assert kce.get_min_and_max_numbers("2-5-8") == [2, 8]
+
+
+def test_get_min_and_max_numbers_floats():
+    # '1.5-3.5' -> [1.5, 3.5]
+    assert kce.get_min_and_max_numbers("1.5-3.5") == [1.5, 3.5]
+
+
+def test_get_min_and_max_numbers_empty_string():
+    assert kce.get_min_and_max_numbers("") == []
+
+
+def test_get_min_and_max_numbers_whitespace():
+    assert kce.get_min_and_max_numbers("   ") == []
+
+
+def test_get_min_and_max_numbers_underscore_separator():
+    # '_' is translated to space by str.maketrans
+    assert kce.get_min_and_max_numbers("5.5_10.5") == [5.5, 10.5]
+
+
+def test_get_min_and_max_numbers_comma_separator():
+    # ',' is translated to space by str.maketrans -> '1 3' -> [1, 3]
+    assert kce.get_min_and_max_numbers("1,3") == [1, 3]
+
+
+# ---------------------------------------------------------------------------
+# complete_num_array
+# ---------------------------------------------------------------------------
+
+def test_complete_num_array_fills_gaps():
+    assert kce.complete_num_array([1, 3]) == [1, 2, 3]
+
+
+def test_complete_num_array_larger_gap():
+    assert kce.complete_num_array([1, 5]) == [1, 2, 3, 4, 5]
+
+
+def test_complete_num_array_empty():
+    assert kce.complete_num_array([]) == []
+
+
+def test_complete_num_array_single_element():
+    assert kce.complete_num_array([3]) == [3]
+
+
+def test_complete_num_array_floats_truncated_to_int_range():
+    # FLAG: int(min)=1, int(max)=3 -> range(1, 4) -> [1, 2, 3]
+    # The float inputs are truncated to ints for the range generation.
+    assert kce.complete_num_array([1.5, 3.5]) == [1, 2, 3]
+
+
+def test_complete_num_array_same_value_twice():
+    # min==max -> range(5, 6) -> [5]
+    assert kce.complete_num_array([5, 5]) == [5]
+
+
+def test_complete_num_array_reversed_input():
+    # min=1, max=3 regardless of input order
+    assert kce.complete_num_array([3, 1]) == [1, 2, 3]
+
+
+def test_complete_num_array_non_contiguous_three_values():
+    # [2, 4, 6] -> min=2, max=6 -> range(2, 7) -> [2, 3, 4, 5, 6]
+    assert kce.complete_num_array([2, 4, 6]) == [2, 3, 4, 5, 6]
+
+
+# ---------------------------------------------------------------------------
+# abbreviate_numbers
+# ---------------------------------------------------------------------------
+
+def test_abbreviate_numbers_contiguous_range():
+    assert kce.abbreviate_numbers([1, 2, 3]) == "1-3"
+
+
+def test_abbreviate_numbers_two_ranges():
+    assert kce.abbreviate_numbers([1, 2, 3, 5, 6]) == "1-3, 5-6"
+
+
+def test_abbreviate_numbers_single_element():
+    assert kce.abbreviate_numbers([1]) == "1"
+
+
+def test_abbreviate_numbers_empty():
+    assert kce.abbreviate_numbers([]) == ""
+
+
+def test_abbreviate_numbers_all_individual():
+    # [1, 3, 5] -> no runs of consecutive ints -> "1, 3, 5"
+    assert kce.abbreviate_numbers([1, 3, 5]) == "1, 3, 5"
+
+
+def test_abbreviate_numbers_long_contiguous_run():
+    assert kce.abbreviate_numbers([1, 2, 3, 4, 5]) == "1-5"
+
+
+def test_abbreviate_numbers_mixed_range_and_single():
+    # [1, 2, 4, 5, 6] -> "1-2, 4-6"
+    assert kce.abbreviate_numbers([1, 2, 4, 5, 6]) == "1-2, 4-6"
+
+
+def test_abbreviate_numbers_single_large():
+    assert kce.abbreviate_numbers([10]) == "10"
+
+
+def test_abbreviate_numbers_two_separate_ranges():
+    assert kce.abbreviate_numbers([1, 2, 3, 10, 11, 12]) == "1-3, 10-12"
+
+
+# ---------------------------------------------------------------------------
+# has_one_set_of_numbers
+# ---------------------------------------------------------------------------
+
+def test_has_one_set_of_numbers_volume_keyword():
+    assert kce.has_one_set_of_numbers("Volume 1") is True
+
+
+def test_has_one_set_of_numbers_range_counts_as_one():
+    # FLAG: a hyphen-separated range like '1-3' matches as ONE set (the regex
+    # matches the full token including the hyphen). Not two sets.
+    assert kce.has_one_set_of_numbers("Vol 1-3") is True
+
+
+def test_has_one_set_of_numbers_no_numbers():
+    assert kce.has_one_set_of_numbers("No numbers here") is False
+
+
+def test_has_one_set_of_numbers_two_volume_keywords():
+    # Two separate volume number matches -> False (len(search) != 1)
+    assert kce.has_one_set_of_numbers("Vol 1 Vol 2") is False
+
+
+def test_has_one_set_of_numbers_lowercase_v():
+    assert kce.has_one_set_of_numbers("v01") is True
+
+
+def test_has_one_set_of_numbers_bare_number():
+    assert kce.has_one_set_of_numbers("1") is True
+
+
+def test_has_one_set_of_numbers_chapter_mode():
+    assert kce.has_one_set_of_numbers("chapter 5", chapter=True) is True
+
+
+def test_has_one_set_of_numbers_volume_mode_explicit():
+    assert kce.has_one_set_of_numbers("volume 1", chapter=False) is True
+
+
+def test_has_one_set_of_numbers_two_lowercase_v():
+    assert kce.has_one_set_of_numbers("v01 v02") is False
+
+
+# ---------------------------------------------------------------------------
+# contains_non_numeric
+# ---------------------------------------------------------------------------
+
+def test_contains_non_numeric_pure_integer_string():
+    # '123' -> float('123') succeeds -> False
+    assert kce.contains_non_numeric("123") is False
+
+
+def test_contains_non_numeric_decimal_string():
+    # '3.14' -> float succeeds -> False
+    assert kce.contains_non_numeric("3.14") is False
+
+
+def test_contains_non_numeric_alpha_string():
+    assert kce.contains_non_numeric("abc") is True
+
+
+def test_contains_non_numeric_alphanumeric():
+    # '1a' -> float fails -> not '1a'.isdigit() -> True
+    assert kce.contains_non_numeric("1a") is True
+
+
+def test_contains_non_numeric_empty_string():
+    # FLAG: float('') raises ValueError, then ''.isdigit() is False -> True
+    # An empty string is considered to "contain non-numeric" content.
+    assert kce.contains_non_numeric("") is True
+
+
+def test_contains_non_numeric_zero():
+    assert kce.contains_non_numeric("0") is False
+
+
+# ---------------------------------------------------------------------------
+# extract_all_numbers
+# ---------------------------------------------------------------------------
+
+def test_extract_all_numbers_volume_keyword():
+    # 'Volume 1' -> [1]
+    assert kce.extract_all_numbers("Volume 1") == [1]
+
+
+def test_extract_all_numbers_range_returns_nested_list():
+    # 'Vol 1-3' -> [[1, 3]] (range stored as nested list)
+    assert kce.extract_all_numbers("Vol 1-3") == [[1, 3]]
+
+
+def test_extract_all_numbers_no_numbers():
+    assert kce.extract_all_numbers("No numbers here") == []
+
+
+def test_extract_all_numbers_lowercase_v_no_match():
+    # FLAG: 'v01' alone does not match extract_all_numbers' regex — needs a
+    # recognized keyword prefix with a word boundary. Result is empty.
+    assert kce.extract_all_numbers("v01") == []
+
+
+def test_extract_all_numbers_decimal():
+    # 'Volume 2.5' -> [2.5]
+    assert kce.extract_all_numbers("Volume 2.5") == [2.5]
+
+
+def test_extract_all_numbers_x_suffix_stripped():
+    # 'Vol 5x2' -> x-part stripped -> [5]
+    assert kce.extract_all_numbers("Vol 5x2") == [5]
+
+
+def test_extract_all_numbers_hash_stripped():
+    # 'v10 #5' -> hash-part stripped -> [5] (only the bare digit prefix remains)
+    assert kce.extract_all_numbers("v10 #5") == [5]
+
+
+def test_extract_all_numbers_volume_mode():
+    assert kce.extract_all_numbers("volume 3") == [3]
+
+
+def test_extract_all_numbers_volume_decimal_mode():
+    assert kce.extract_all_numbers("vol 3.5") == [3.5]
+
+
+def test_extract_all_numbers_chapter_keyword():
+    assert kce.extract_all_numbers("Chapter 10") == [10]
+
+
+def test_extract_all_numbers_with_subtitle():
+    # Subtitle stripped before extraction -> 'Volume 5 - My Subtitle' -> [5]
+    assert kce.extract_all_numbers("Volume 5 - My Subtitle", subtitle="My Subtitle") == [5]
+
+
+def test_extract_all_numbers_series_name_no_keyword():
+    # Pure series name with no recognized keyword -> []
+    assert kce.extract_all_numbers("Series Name") == []
+
+
+def test_extract_all_numbers_part_keyword():
+    # 'Vol 1 Part 2' - only the first recognized set is returned
+    assert kce.extract_all_numbers("Vol 1 Part 2") == [1]
+
+
+# ---------------------------------------------------------------------------
+# has_multiple_numbers
+# ---------------------------------------------------------------------------
+
+def test_has_multiple_numbers_single_volume():
+    # 'Volume 1' -> ['1'] -> len 1 -> False
+    assert kce.has_multiple_numbers("Volume 1") is False
+
+
+def test_has_multiple_numbers_range_has_two():
+    # 'Vol 1-3' -> ['1', '3'] -> len 2 -> True
+    assert kce.has_multiple_numbers("Vol 1-3") is True
+
+
+def test_has_multiple_numbers_decimal_is_one_match():
+    # FLAG: 'Chapter 1.5' -> regex \d+\.[0-9]+ matches '1.5' as one token -> False
+    # (legacy tests.py may have incorrectly expected True for this input)
+    assert kce.has_multiple_numbers("Chapter 1.5") is False
+
+
+def test_has_multiple_numbers_no_numbers():
+    assert kce.has_multiple_numbers("No numbers") is False
+
+
+def test_has_multiple_numbers_two_separate_numbers():
+    # '1 2' -> ['1', '2'] -> len 2 -> True
+    assert kce.has_multiple_numbers("1 2") is True
+
+
+def test_has_multiple_numbers_single_large():
+    assert kce.has_multiple_numbers("10") is False
+
+
+def test_has_multiple_numbers_single_decimal():
+    # '10.5' -> ['10.5'] -> len 1 -> False
+    assert kce.has_multiple_numbers("10.5") is False
+
+
+def test_has_multiple_numbers_two_zero_decimals():
+    # '2.0' -> matches \d+\.[0-9]+ as one token -> False
+    assert kce.has_multiple_numbers("2.0") is False
+
+
+def test_has_multiple_numbers_v_prefix():
+    # 'v01' -> ['01'] -> len 1 -> False
+    assert kce.has_multiple_numbers("v01") is False
+
+
+def test_has_multiple_numbers_v_prefix_two():
+    # 'v01 c02' -> ['01', '02'] -> len 2 -> True
+    assert kce.has_multiple_numbers("v01 c02") is True

--- a/tests/utils/test_predicates_smoke.py
+++ b/tests/utils/test_predicates_smoke.py
@@ -1,0 +1,183 @@
+"""Smoke characterization tests for small predicate / utility wrappers.
+
+Each test makes ONE assertion pinning the real observed return value (verified
+against .venv/bin/python -c "..." before writing). Surprising behaviour is
+noted with a # FLAG: comment rather than being "fixed".
+
+Functions covered (all from komga_cover_extractor.py):
+    contains_brackets, starts_with_bracket, ends_with_bracket,
+    ends_with_starting_bracket, contains_unicode, contains_punctuation,
+    get_file_extension, get_extensionless_name, array_to_string, get_sort_key
+"""
+
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# contains_brackets
+# ---------------------------------------------------------------------------
+
+def test_contains_brackets_with_parens():
+    assert kce.contains_brackets("hello(world)") is True
+
+
+def test_contains_brackets_plain_string():
+    assert kce.contains_brackets("hello") is False
+
+
+def test_contains_brackets_square():
+    assert kce.contains_brackets("[test]") is True
+
+
+# ---------------------------------------------------------------------------
+# starts_with_bracket
+# ---------------------------------------------------------------------------
+
+def test_starts_with_bracket_true():
+    assert kce.starts_with_bracket("(hello)") is True
+
+
+def test_starts_with_bracket_false():
+    assert kce.starts_with_bracket("hello") is False
+
+
+# ---------------------------------------------------------------------------
+# ends_with_bracket  (closing brackets)
+# ---------------------------------------------------------------------------
+
+def test_ends_with_bracket_true():
+    assert kce.ends_with_bracket("hello)") is True
+
+
+def test_ends_with_bracket_false():
+    assert kce.ends_with_bracket("hello") is False
+
+
+# ---------------------------------------------------------------------------
+# ends_with_starting_bracket  (opening brackets at the end)
+# ---------------------------------------------------------------------------
+
+def test_ends_with_starting_bracket_true():
+    assert kce.ends_with_starting_bracket("hello(") is True
+
+
+def test_ends_with_starting_bracket_closing_is_false():
+    # A closing bracket does NOT match — only opening brackets count.
+    assert kce.ends_with_starting_bracket("hello)") is False
+
+
+# ---------------------------------------------------------------------------
+# contains_unicode
+# ---------------------------------------------------------------------------
+
+def test_contains_unicode_ascii_is_false():
+    assert kce.contains_unicode("hello") is False
+
+
+def test_contains_unicode_accented_char():
+    assert kce.contains_unicode("héllo") is True
+
+
+def test_contains_unicode_kanji():
+    assert kce.contains_unicode("日本語") is True
+
+
+# ---------------------------------------------------------------------------
+# contains_punctuation
+# ---------------------------------------------------------------------------
+
+def test_contains_punctuation_exclamation():
+    assert kce.contains_punctuation("hello!") is True
+
+
+def test_contains_punctuation_plain_false():
+    assert kce.contains_punctuation("hello") is False
+
+
+def test_contains_punctuation_comma():
+    assert kce.contains_punctuation("hello, world") is True
+
+
+# ---------------------------------------------------------------------------
+# get_file_extension
+# ---------------------------------------------------------------------------
+
+def test_get_file_extension_cbz():
+    assert kce.get_file_extension("manga.cbz") == ".cbz"
+
+
+def test_get_file_extension_no_ext():
+    assert kce.get_file_extension("manga") == ""
+
+
+def test_get_file_extension_hidden_file():
+    # os.path.splitext(".hidden") -> ('.hidden', '') so extension is ''
+    # FLAG: hidden files (dot-files with no second dot) return '' not '.hidden'
+    assert kce.get_file_extension(".hidden") == ""
+
+
+def test_get_file_extension_double_ext_returns_last():
+    # os.path.splitext("file.tar.gz") -> ('file.tar', '.gz')
+    assert kce.get_file_extension("file.tar.gz") == ".gz"
+
+
+# ---------------------------------------------------------------------------
+# get_extensionless_name
+# ---------------------------------------------------------------------------
+
+def test_get_extensionless_name_strips_ext():
+    assert kce.get_extensionless_name("manga.cbz") == "manga"
+
+
+def test_get_extensionless_name_hidden_file_unchanged():
+    # os.path.splitext(".hidden") -> ('.hidden', '') so stem is '.hidden'
+    assert kce.get_extensionless_name(".hidden") == ".hidden"
+
+
+def test_get_extensionless_name_no_ext():
+    assert kce.get_extensionless_name("no_ext") == "no_ext"
+
+
+# ---------------------------------------------------------------------------
+# array_to_string  (signature: array_to_string(array, separator=", "))
+# ---------------------------------------------------------------------------
+
+def test_array_to_string_int_list():
+    assert kce.array_to_string([1, 2, 3]) == "1, 2, 3"
+
+
+def test_array_to_string_str_list():
+    assert kce.array_to_string(["a", "b"]) == "a, b"
+
+
+def test_array_to_string_custom_separator():
+    assert kce.array_to_string(["a", "b"], " | ") == "a | b"
+
+
+def test_array_to_string_non_list_string():
+    # Non-list input: str(array) is returned directly
+    assert kce.array_to_string("not a list") == "not a list"
+
+
+def test_array_to_string_non_list_int():
+    assert kce.array_to_string(42) == "42"
+
+
+# ---------------------------------------------------------------------------
+# get_sort_key
+# ---------------------------------------------------------------------------
+
+def test_get_sort_key_scalar_int():
+    assert kce.get_sort_key(5) == 5
+
+
+def test_get_sort_key_scalar_float():
+    assert kce.get_sort_key(3.5) == 3.5
+
+
+def test_get_sort_key_list_returns_min():
+    assert kce.get_sort_key([3, 1, 4]) == 1
+
+
+def test_get_sort_key_singleton_list():
+    assert kce.get_sort_key([10]) == 10

--- a/tests/utils/test_string_transforms.py
+++ b/tests/utils/test_string_transforms.py
@@ -1,0 +1,467 @@
+"""Characterization tests for string-transform utilities.
+
+Every assertion was verified against::
+
+    .venv/bin/python -c "import komga_cover_extractor as kce; print(repr(kce.FUNC(ARGS)))"
+
+before being written here.  Surprising/buggy behaviour is noted with
+``# FLAG:`` comments and is pinned AS-IS — not "fixed".
+
+Functions covered (all from komga_cover_extractor.py):
+    remove_dual_space, normalize_str, remove_s, remove_punctuation,
+    clean_str, remove_brackets, replace_underscores
+"""
+
+import pytest
+import komga_cover_extractor as kce
+
+
+# ---------------------------------------------------------------------------
+# remove_dual_space
+# ---------------------------------------------------------------------------
+
+def test_remove_dual_space_triple_space_collapses_to_single():
+    assert kce.remove_dual_space("a   b") == "a b"
+
+
+def test_remove_dual_space_double_space_collapses():
+    assert kce.remove_dual_space("hello  world") == "hello world"
+
+
+def test_remove_dual_space_no_double_space_unchanged():
+    assert kce.remove_dual_space("no double") == "no double"
+
+
+def test_remove_dual_space_multiple_gaps():
+    assert kce.remove_dual_space("a  b  c") == "a b c"
+
+
+def test_remove_dual_space_empty_string():
+    assert kce.remove_dual_space("") == ""
+
+
+def test_remove_dual_space_no_space_unchanged():
+    assert kce.remove_dual_space("single") == "single"
+
+
+def test_remove_dual_space_all_spaces_collapses_to_one():
+    # Four spaces -> collapses to one space (dual_space_pattern is greedy)
+    assert kce.remove_dual_space("    ") == " "
+
+
+# ---------------------------------------------------------------------------
+# normalize_str
+# ---------------------------------------------------------------------------
+
+def test_normalize_str_removes_article_the():
+    # "the" is a common word and is stripped; "Hero" stays
+    assert kce.normalize_str("The Hero is Overpowered") == "Hero is Overpowered"
+
+
+def test_normalize_str_removes_article_a():
+    assert kce.normalize_str("a simple string") == "simple string"
+
+
+def test_normalize_str_short_string_returned_unchanged():
+    # len <= 1 short-circuits the function
+    assert kce.normalize_str("a") == "a"
+
+
+def test_normalize_str_empty_string():
+    assert kce.normalize_str("") == ""
+
+
+def test_normalize_str_removes_series_keyword_not_at_start():
+    # FLAG: "(?<!^)Series\s" requires a trailing space after the keyword.
+    # "My Series" has no trailing space, so 'Series' is NOT stripped.
+    assert kce.normalize_str("My Series") == "My Series"
+
+
+def test_normalize_str_removes_manga_not_at_start():
+    # "(?<!^)Manga\s" requires a trailing space; "My Manga" has none -> stays
+    # FLAG: "My Manga" is NOT stripped because the pattern needs a trailing space
+    assert kce.normalize_str("My Manga") == "My Manga"
+
+
+def test_normalize_str_removes_manga_when_followed_by_space():
+    # "My Manga Series" -> Manga is followed by space -> stripped, then Series stripped
+    assert kce.normalize_str("My Manga Series") == "My Series"
+
+
+def test_normalize_str_manga_at_start_preserved():
+    # (?<!^) lookbehind prevents stripping when Manga starts the string
+    assert kce.normalize_str("Manga Collection") == "Manga"
+
+
+def test_normalize_str_removes_edition_keywords():
+    # "Edition" is in the editions list
+    assert kce.normalize_str("Special Edition Manga") == "Manga"
+
+
+def test_normalize_str_removes_deluxe_collection():
+    assert kce.normalize_str("Deluxe Collection") == ""
+
+
+def test_normalize_str_removes_volume_in_middle():
+    assert kce.normalize_str("One Piece Volume 1") == "One Piece 1"
+
+
+def test_normalize_str_book_at_start_preserved():
+    # "(?<!^)Book" -> Book at start is NOT stripped
+    assert kce.normalize_str("Novel Series") == "Novel Series"
+
+
+def test_normalize_str_removes_japanese_particle_to():
+    # "to" is in japanese_particles
+    assert kce.normalize_str("I go to school") == "go school"
+
+
+def test_normalize_str_removes_bookwalker():
+    # BookWalker is a storefront keyword; "Exclusive" is in editions
+    assert kce.normalize_str("BookWalker Exclusive") == ""
+
+
+def test_normalize_str_skip_common_words_leaves_the():
+    assert kce.normalize_str("the quick brown fox", skip_common_words=True) == "the quick brown fox"
+
+
+def test_normalize_str_skip_editions_leaves_edition_word():
+    assert kce.normalize_str("Digital Edition", skip_editions=True) == "Digital Edition"
+
+
+def test_normalize_str_skip_storefront_leaves_bookwalker():
+    # Without storefront removal, BookWalker stays; Exclusive is an edition word and is removed
+    assert kce.normalize_str("BookWalker Exclusive", skip_storefront_keywords=True) == "BookWalker"
+
+
+def test_normalize_str_skip_misc_words_leaves_x_hd():
+    # x and HD are misc_words; skip_misc keeps them; Edition is still removed
+    assert kce.normalize_str("Volume 3 x HD Edition", skip_misc_words=True) == "Volume 3 x HD"
+
+
+def test_normalize_str_skip_type_keywords_true_raises_when_other_words_present():
+    # FLAG: bug — when skip_type_keywords=True but at least one other word category
+    # is active, the for-loop body references the unbound local `type_keywords`,
+    # raising UnboundLocalError (a NameError subclass).
+    with pytest.raises(NameError, match="type_keywords"):
+        kce.normalize_str("My Series Test", skip_type_keywords=True)
+
+
+def test_normalize_str_all_skip_true_returns_input():
+    # When ALL categories are skipped, words_to_remove is empty, the loop never
+    # executes, and `type_keywords` is never referenced — so no error.
+    result = kce.normalize_str(
+        "The Hero Manga",
+        skip_common_words=True,
+        skip_editions=True,
+        skip_type_keywords=True,
+        skip_japanese_particles=True,
+        skip_misc_words=True,
+        skip_storefront_keywords=True,
+    )
+    assert result == "The Hero Manga"
+
+
+# ---------------------------------------------------------------------------
+# remove_s
+# ---------------------------------------------------------------------------
+
+def test_remove_s_strips_trailing_s_from_this():
+    # FLAG: remove_s strips trailing 's' from EVERY word unconditionally,
+    # so 'this' -> 'thi'
+    assert kce.remove_s("this") == "thi"
+
+
+def test_remove_s_strips_trailing_s_from_series():
+    # FLAG: 'series' -> 'serie'
+    assert kce.remove_s("series") == "serie"
+
+
+def test_remove_s_strips_from_heroes():
+    assert kce.remove_s("heroes") == "heroe"
+
+
+def test_remove_s_no_change_when_no_s():
+    assert kce.remove_s("one piece") == "one piece"
+
+
+def test_remove_s_multiple_words():
+    assert kce.remove_s("cats and dogs") == "cat and dog"
+
+
+def test_remove_s_single_word_books():
+    assert kce.remove_s("books") == "book"
+
+
+def test_remove_s_case_insensitive():
+    # FLAG: works case-insensitively — 'SERIES' -> 'SERIE'
+    assert kce.remove_s("SERIES") == "SERIE"
+
+
+def test_remove_s_word_ending_in_is():
+    # FLAG: 'crisis' -> 'crisi' because \b(\\w+)(s)\b matches 'i' as \\w+ and 's'
+    assert kce.remove_s("crisis") == "crisi"
+
+
+def test_remove_s_word_without_s_unchanged():
+    assert kce.remove_s("x") == "x"
+
+
+def test_remove_s_books_volumes_chapters():
+    assert kce.remove_s("books volumes chapters") == "book volume chapter"
+
+
+# ---------------------------------------------------------------------------
+# remove_punctuation
+# ---------------------------------------------------------------------------
+
+def test_remove_punctuation_comma_and_exclamation():
+    # Comma and ! are replaced by space; two consecutive -> double space
+    assert kce.remove_punctuation("hello, world!") == "hello  world"
+
+
+def test_remove_punctuation_period():
+    assert kce.remove_punctuation("test.file") == "test file"
+
+
+def test_remove_punctuation_no_punctuation_unchanged():
+    assert kce.remove_punctuation("no punctuation") == "no punctuation"
+
+
+def test_remove_punctuation_colon():
+    assert kce.remove_punctuation("title: subtitle") == "title  subtitle"
+
+
+def test_remove_punctuation_hyphens():
+    assert kce.remove_punctuation("a-b-c") == "a b c"
+
+
+def test_remove_punctuation_apostrophe():
+    assert kce.remove_punctuation("it's") == "it s"
+
+
+def test_remove_punctuation_percent():
+    assert kce.remove_punctuation("100%") == "100"
+
+
+def test_remove_punctuation_plus_preserved():
+    # FLAG: punctuation_pattern is [^\w\s+], so '+' is NOT treated as punctuation
+    # and is left intact.
+    assert kce.remove_punctuation("a+b") == "a+b"
+
+
+def test_remove_punctuation_plus_with_spaces_preserved():
+    assert kce.remove_punctuation("a + b") == "a + b"
+
+
+# ---------------------------------------------------------------------------
+# replace_underscores
+# ---------------------------------------------------------------------------
+
+def test_replace_underscores_digit_underscore_digit_becomes_period():
+    # Underscore between two digits is replaced with a period
+    assert kce.replace_underscores("Series_1_5") == "Series 1.5"
+
+
+def test_replace_underscores_word_underscore_word_becomes_space():
+    assert kce.replace_underscores("hello_world") == "hello world"
+
+
+def test_replace_underscores_chain_of_digit_underscores():
+    assert kce.replace_underscores("chapter_1_2_3") == "chapter 1.2.3"
+
+
+def test_replace_underscores_digit_only_chain():
+    assert kce.replace_underscores("1_2_3") == "1.2.3"
+
+
+def test_replace_underscores_no_underscore_unchanged():
+    assert kce.replace_underscores("plain") == "plain"
+
+
+def test_replace_underscores_leading_underscore_removed():
+    assert kce.replace_underscores("_leading") == "leading"
+
+
+def test_replace_underscores_trailing_underscore_removed():
+    assert kce.replace_underscores("trailing_") == "trailing"
+
+
+def test_replace_underscores_word_then_digit():
+    # Non-digit before underscore -> space not period
+    assert kce.replace_underscores("word_1") == "word 1"
+
+
+def test_replace_underscores_digit_then_word():
+    assert kce.replace_underscores("1_vol") == "1 vol"
+
+
+def test_replace_underscores_mixed():
+    # Mix: digit_digit -> period, word_word -> space
+    assert kce.replace_underscores("Series_1_5_extra") == "Series 1.5 extra"
+
+
+# ---------------------------------------------------------------------------
+# remove_brackets
+# ---------------------------------------------------------------------------
+
+def test_remove_brackets_year_in_parens():
+    assert kce.remove_brackets("Series Name (2021)") == "Series Name"
+
+
+def test_remove_brackets_whole_string_bracket_avoidance():
+    # The string starts AND ends with a bracket -> whole-string avoidance; unchanged
+    assert kce.remove_brackets("[(OSHI NO KO)]") == "[(OSHI NO KO)]"
+
+
+def test_remove_brackets_single_square_bracket_wrapping():
+    # '[OSHI NO KO]' starts and ends with bracket -> whole-string avoidance
+    assert kce.remove_brackets("[OSHI NO KO]") == "[OSHI NO KO]"
+
+
+def test_remove_brackets_paren_wrapping_whole_string():
+    # '(just brackets)' starts and ends with bracket -> avoidance
+    assert kce.remove_brackets("(just brackets)") == "(just brackets)"
+
+
+def test_remove_brackets_digital_with_cbz_extension():
+    # Extension is preserved; bracketed info before ext removed
+    assert kce.remove_brackets("Series Name (Digital).cbz") == "Series Name.cbz"
+
+
+def test_remove_brackets_scanlator_square_brackets():
+    # '[Scanlator]' is adjacent to letters -> avoidance rule; not removed
+    assert kce.remove_brackets("My Series [Scanlator]") == "My Series [Scanlator]"
+
+
+def test_remove_brackets_curly_braces():
+    # FLAG: '{info}' (preceded by a space and not preceded by digits) is NOT
+    # removed by bracket_removal_pattern — curly braces without a year digit
+    # and adjacent to text are left intact.
+    assert kce.remove_brackets("Test {info}") == "Test {info}"
+
+
+def test_remove_brackets_year_in_square_brackets():
+    assert kce.remove_brackets("Test [2021]") == "Test"
+
+
+def test_remove_brackets_trailing_year_curly():
+    assert kce.remove_brackets("Test {2021}") == "Test"
+
+
+def test_remove_brackets_plain_string_unchanged():
+    assert kce.remove_brackets("normal string") == "normal string"
+
+
+def test_remove_brackets_cbz_year_stripped_extra_info_stays():
+    # year bracket is removed; [v02] stays (adjacent to letters/preceded by space)
+    assert kce.remove_brackets("Series Name [v02] (2021).cbz") == "Series Name [v02].cbz"
+
+
+# ---------------------------------------------------------------------------
+# clean_str  (the full normalization pipeline)
+# ---------------------------------------------------------------------------
+
+def test_clean_str_article_and_stopword_removal():
+    # 'The' removed by normalize, 'is' stripped via remove_s ('i' is left) -> 'i'
+    assert kce.clean_str("The Hero is Overpowered") == "hero i overpowered"
+
+
+def test_clean_str_accented_string_unidecoded():
+    # 'Héros' -> unidecode -> 'Heros' -> normalize removes nothing -> remove_s -> 'Hero'
+    # then lower -> 'hero'
+    assert kce.clean_str("Héros") == "hero"
+
+
+def test_clean_str_underscore_digit_becomes_period():
+    # 'Series_1_5' -> lower -> normalize (no change) -> underscore: 1_5 -> 1.5
+    assert kce.clean_str("Series_1_5") == "series 1.5"
+
+
+def test_clean_str_colon_replaced_by_space():
+    # 'My Series: A Story' -> colon -> space -> normalize removes 'a', 'Series'
+    # -> 'My Story' -> remove_s -> 'My Story' (no trailing s on each)
+    assert kce.clean_str("My Series: A Story") == "my story"
+
+
+def test_clean_str_double_space_collapsed():
+    assert kce.clean_str("  double  space  ") == "double space"
+
+
+def test_clean_str_brackets_stripped():
+    # '(2021)' bracket removed; 'Serie' from normalize -> 'serie' after remove_s
+    assert kce.clean_str("Series Name (2021)") == "serie name"
+
+
+def test_clean_str_whole_string_brackets_normalized():
+    # '[(OSHI NO KO)]' bracket avoidance -> kept as is -> lower -> normalize
+    # removes 'no' (japanese particle) -> 'oshi ko' after remove_s ('oshi', 'ko')
+    assert kce.clean_str("[(OSHI NO KO)]") == "oshi ko"
+
+
+def test_clean_str_empty_string():
+    assert kce.clean_str("") == ""
+
+
+def test_clean_str_lowercase_conversion():
+    assert kce.clean_str("UPPERCASE") == "uppercase"
+
+
+def test_clean_str_underscore_words():
+    assert kce.clean_str("hello_world_test") == "hello world test"
+
+
+def test_clean_str_skip_lowercase_convert():
+    # Without lowercasing: 'The Hero is Overpowered' -> articles stripped -> 'Hero i Overpowered'
+    assert kce.clean_str("The Hero is Overpowered", skip_lowercase_convert=True) == "Hero i Overpowered"
+
+
+def test_clean_str_skip_normalize():
+    # normalize_str skipped so 'the' and 'is' are kept; remove_s still runs
+    assert kce.clean_str("The Hero is Overpowered", skip_normalize=True) == "the hero i overpowered"
+
+
+def test_clean_str_skip_remove_s():
+    # remove_s skipped; 'is' stays; 'the' removed by normalize
+    assert kce.clean_str("The Hero is Overpowered", skip_remove_s=True) == "hero is overpowered"
+
+
+def test_clean_str_skip_underscore():
+    # Underscore replacement skipped -> underscores stay as is
+    assert kce.clean_str("Series_1_5", skip_underscore=True) == "series_1_5"
+
+
+def test_clean_str_skip_unidecode_keeps_accent():
+    # Unidecode skipped; 'Héros' -> lower -> 'héros'; normalize does nothing;
+    # remove_s: 'héro' (strips trailing 's'); encode ascii ignore -> 'hro'
+    # FLAG: skipping unidecode causes the accented char to be dropped by ascii encode
+    assert kce.clean_str("Héros", skip_unidecode=True) == "hro"
+
+
+def test_clean_str_with_colon_and_volume():
+    # 'My Series: Volume 2' -> colon -> 'My Series Volume 2' -> normalize removes Series, Volume
+    assert kce.clean_str("My Series: Volume 2") == "my 2"
+
+
+def test_clean_str_single_char():
+    assert kce.clean_str("A") == "a"
+
+
+def test_clean_str_single_char_x():
+    assert kce.clean_str("x") == "x"
+
+
+def test_clean_str_cafe_accent():
+    # 'Café au lait' -> unidecode -> 'Cafe au lait' -> normalize removes 'a' -> 'Cafe lait'
+    # -> lower -> 'cafe lait' -> remove_s -> no trailing s -> 'cafe au lait'
+    # Wait - 'au' has no 's'; 'lait' has no 's' -> 'cafe au lait'
+    assert kce.clean_str("Café au lait") == "cafe au lait"
+
+
+def test_clean_str_skip_bracket_keeps_year():
+    # skip_bracket=True means bracket removal is skipped; 'Overlord' has no brackets
+    assert kce.clean_str("Overlord", skip_bracket=True) == "overlord"
+
+
+def test_clean_str_my_hero_academia_underscores():
+    assert kce.clean_str("My_Hero_Academia") == "my hero academia"


### PR DESCRIPTION
## Summary

Adds a **pytest characterization safety net** (`tests/`, 1,413 tests) for the single-file `komga_cover_extractor.py`, so future refactors (e.g. modularization) are provably behavior-preserving. The tests **pin current behavior** ("what it does today"), not "what is correct" — surprising/buggy behavior is pinned **as-is** with a `# FLAG:` comment and **never changed**. No production code is modified.

> **Stacked on #26** (`library-replacements`). The tests pin behavior of the maintained-library swaps from that PR (xxhash digests, rapidfuzz scores, imagehash phash, xmltodict shapes), so this branch is based on it. Until #26 merges, the diff here includes #26's changes; afterward it reduces to the `tests/` additions only.

## What's added

- **`pyproject.toml`** — `[tool.pytest.ini_options]` (`testpaths=tests`, `--import-mode=importlib`, `pythonpath`). `tests/` is intentionally **not** a Python package (no `__init__.py`) so `import tests` still resolves to the existing `tests.py` runner.
- **`requirements-dev.txt`** — `pytest` (dev-only; not needed to run the app or the Docker image).
- **`tests/conftest.py`** — autouse `isolated_globals` fixture (deep-snapshots every module global, restores after each test, clears all 24 `lru_cache`s via runtime introspection) + in-memory `cbz`/`zip`/`ComicInfo.xml`/image/tmp-tree/requests-mock fixtures.
- **`tests/regression_gate.py`** — runs each legacy `tests.py` test **independently** (fresh process) and asserts the baseline **35 pass / 4 known-fail / 0 new**.
- **`tests/` suites** (~33 files): parsing pipeline (358), number/string utils + similarity (248), archive handling (163), cover extraction + image similarity (94), filesystem ops (142), upgrade/scoring engine + a full-field `Volume` golden snapshot (381), external services via mocks (21), plus scaffolding/smoke.

## Compatibility

- The legacy `python3 tests.py` runner, the Dockerfile, and the GitHub Actions workflows are **untouched**.
- `import tests` still resolves to `tests.py` (verified).

## Verification

```
.venv/bin/pytest tests/ -q                  # 1413 passed
.venv/bin/python tests/regression_gate.py   # 35 pass / 4 known-fail / 0 new
```

## Notable behaviors pinned as-is (documented, not fixed)

- **phash mis-calibration**: blank white vs black scores `0.984375`, and every solid-color cover collapses to white's phash → `compare_images == 1.0`, so `blank_cover_required_similarity_score = 0.9` would flag any solid cover as blank. (Path is off by default.)
- `get_release_number` returns a **tuple** `(1,3)` for multi-volume but `get_release_number_cache` returns a **list** `[1,3]`; callers branch on `isinstance(x, list)`. Downstream, `is_same_index_number(1, (1,3), allow_array_match=True)` is `False` (tuple) vs `True` (list).
- `get_release_year` returns `str` from a filename but `int` from metadata; floor is 1950; a lone `Year` is ignored unless `Summary` is also present.
- `normalize_str(skip_type_keywords=True)` raises `UnboundLocalError`; `remove_s` strips a trailing `s` from every word.
- `is_upgradeable` reuses `results[0]` for both sides when the names are equal (identical names never upgrade); `parse_words` computes a unidecode result then ignores it; `clean_and_sort(sort=True)` mutates the caller's list in place.
- Error-swallowing sentinels: `get_zip_comment`→`''`, `contains_comic_info`→`False`, `find_and_extract_cover`→`None` (missing) vs `False` (no images), `get_komga_libraries`→`None` (guard) vs `[]` (non-200).